### PR TITLE
Feature/debughelper, moving debug to component level

### DIFF
--- a/src/components/helper/Helper.js
+++ b/src/components/helper/Helper.js
@@ -1,0 +1,121 @@
+import React, {useState} from 'react'
+import ReactDOM from 'react-dom'
+import PropTypes from 'prop-types'
+import {Close, Feedback} from '@material-ui/icons'
+import {report} from '../../utils/raven_reporter'
+import {HelMaterialTheme} from '../../themes/material-ui'
+import {Dialog, DialogTitle, DialogContent, IconButton, TextField, withStyles} from '@material-ui/core'
+
+const DebugDialogTitle = withStyles({
+    root: {
+        '& .MuiTypography-root': {
+            alignItems: 'center',
+            display: 'flex',
+            justifyContent: 'space-between',
+        },
+    },
+})(DialogTitle)
+
+const DebugReporterModal = ({showModal, close, sendReport}) => {
+    const [value, setValue] = useState()
+
+    return (
+        <div id='debugreporterform'>
+            <Dialog open={showModal} onClose={close} transitionDuration={0}>
+                <DebugDialogTitle>
+                    Raportoi virhetilanne
+                    <IconButton onClick={() => close()}>
+                        <Close />
+                    </IconButton>
+                </DebugDialogTitle>
+                <DialogContent>
+                    <TextField
+                        multiline
+                        fullWidth
+                        value={value}
+                        label={'Kuvaile ongelmaa halutessasi'}
+                        style={{margin: 0}}
+                        onChange={event => setValue(event.target.value)}
+                    />
+                    <button onClick={() => sendReport(value)} style={{margin: '1rem 0 0'}}>
+                        Lähetä raportti
+                    </button>
+                    <hr />
+                    <small
+                        style={{
+                            display: 'block',
+                            margin: '0 0 10px',
+                        }}>
+                        Sovelluksen versiotunniste:
+                        <br />
+                        {appSettings.commit_hash}
+                    </small>
+                </DialogContent>
+            </Dialog>
+        </div>
+    )
+}
+
+DebugReporterModal.propTypes = {
+    sendReport: PropTypes.func,
+    showModal: PropTypes.bool,
+    close: PropTypes.func,
+}
+
+class DebugHelper extends React.Component {
+    constructor(props) {
+        super(props)
+        this.state = {reporting: false}
+
+        this.showReportForm = this.showReportForm.bind(this)
+        this.closeReportForm = this.closeReportForm.bind(this)
+        this.serializeState = this.serializeState.bind(this)
+    }
+
+    showReportForm() {
+        this.setState({reporting: true})
+    }
+
+    closeReportForm() {
+        this.setState({reporting: false})
+    }
+
+    serializeState(reportmsg) {
+        this.closeReportForm()
+        report(window.ARG, reportmsg, appSettings.commit_hash)
+
+        window.setTimeout(() => alert('Raportti lähetetty, kiitoksia'), 100)
+    }
+
+    render() {
+        return (
+            <div>
+                <DebugReporterModal
+                    showModal={this.state.reporting}
+                    close={this.closeReportForm}
+                    sendReport={this.serializeState}
+                />
+                <div id='debughelper'>
+                    <div id='debughelper_container'>
+                        <button className='btn btn-default' onClick={this.showReportForm}>
+                            <Feedback style={{marginLeft: HelMaterialTheme.spacing(1)}} />
+                        </button>
+                    </div>
+                    <div id='slide'>
+                        Jos tapahtumien hallinnassa tai syöttölomakkeen toiminnassa on virhe, klikkaa{' '}
+                        {`"raportoi virhe"`}&#x2011;nappia, niin saamme virhetilanteesta tiedon ja voimme tutkia asiaa.
+                    </div>
+                </div>
+            </div>
+        )
+    }
+}
+
+ReactDOM.render(
+    <div>
+        <DebugHelper />
+    </div>,
+    document.getElementById('content')
+)
+
+export default DebugHelper

--- a/src/index.jade
+++ b/src/index.jade
@@ -27,8 +27,6 @@ html.no-js
                 a(href=LE_PRODUCTION_INSTANCE) siirry tuotantoon
         div
             #content
-        div
-            #debughelper
         if APP_MODE == 'development'
             script(src="/scripts/main.js", type="text/javascript")
         

--- a/src/index.js
+++ b/src/index.js
@@ -1,11 +1,9 @@
-import React, {useState} from 'react'
+import React from 'react'
 import ReactDOM from 'react-dom'
 import {Route} from 'react-router'
-import PropTypes from 'prop-types'
 import {withRouter} from 'react-router-dom'
 import {Provider, connect} from 'react-redux'
 import {ConnectedRouter} from 'react-router-redux'
-import {Close, Feedback} from '@material-ui/icons'
 
 // Views
 import App from './views/App'
@@ -17,19 +15,17 @@ import Event from './views/Event'
 import EventCreated from './views/EventCreated'
 import EventListingPage from './views/EventListing'
 import ModerationPage from './views/Moderation/Moderation'
+import DebugHelper from './components/helper/Helper'
 
 // Actors
 import Validator from './actors/validator'
 
 // JA addition
 import Serializer from './actors/serializer';
-import {report} from './utils/raven_reporter';
 
 // translation
 import IntlProviderWrapper from './components/IntlProviderWrapper'
 import store, {history} from './store'
-import {HelMaterialTheme} from './themes/material-ui'
-import {Dialog, DialogTitle, DialogContent, IconButton, TextField, withStyles} from '@material-ui/core'
 import moment from 'moment'
 import * as momentTimezone from 'moment-timezone'
 
@@ -59,120 +55,10 @@ ReactDOM.render(
                     <Route exact path="/help" component={Help}/>
                     <Route exact path="/terms" component={Terms}/>
                     <Route exact path="/moderation" component={ModerationPage}/>
+                    <Route path="/" component={DebugHelper}/>
                 </LayoutContainer>
             </ConnectedRouter>
         </IntlProviderWrapper>
     </Provider>,
     document.getElementById('content')
 )
-
-const DebugDialogTitle = withStyles({
-    root: {
-        '& .MuiTypography-root': {
-            alignItems: 'center',
-            display: 'flex',
-            justifyContent: 'space-between',
-        },
-    },
-})(DialogTitle)
-
-const DebugReporterModal = ({showModal, close, sendReport}) => {
-    const [value, setValue] = useState()
-
-    return <div id="debugreporterform">
-        <Dialog
-            open={showModal}
-            onClose={close}
-            transitionDuration={0}
-        >
-            <DebugDialogTitle>
-                Raportoi virhetilanne
-                <IconButton onClick={() => close()}>
-                    <Close />
-                </IconButton>
-            </DebugDialogTitle>
-            <DialogContent>
-                <TextField
-                    multiline
-                    fullWidth
-                    value={value}
-                    label={'Kuvaile ongelmaa halutessasi'}
-                    style={{margin: 0}}
-                    onChange={(event) => setValue(event.target.value)}
-                />
-                <button
-                    onClick={() => sendReport(value)}
-                    style={{margin: '1rem 0 0'}}
-                >
-                    Lähetä raportti
-                </button>
-                <hr/>
-                <small style={{
-                    display: 'block',
-                    margin: '0 0 10px',
-                }}>
-                    Sovelluksen versiotunniste:<br />{appSettings.commit_hash}
-                </small>
-            </DialogContent>
-        </Dialog>
-    </div>
-}
-
-DebugReporterModal.propTypes = {
-    sendReport: PropTypes.func,
-    showModal: PropTypes.bool,
-    close: PropTypes.func,
-}
-
-class DebugHelper extends React.Component {
-    constructor(props) {
-        super(props);
-        this.state = {reporting: false}
-
-        this.showReportForm = this.showReportForm.bind(this)
-        this.closeReportForm = this.closeReportForm.bind(this)
-        this.serializeState = this.serializeState.bind(this)
-    }
-
-    showReportForm() {
-        this.setState({reporting: true})
-    }
-
-    closeReportForm() {
-        this.setState({reporting: false})
-    }
-
-    serializeState(reportmsg) {
-        this.closeReportForm();
-        report(window.ARG, reportmsg, appSettings.commit_hash);
-
-        window.setTimeout(
-            () => alert('Raportti lähetetty, kiitoksia'),
-            100);
-    }
-
-    render() {
-        return <div>
-            <DebugReporterModal showModal={this.state.reporting} close={this.closeReportForm} sendReport={this.serializeState} />
-            <div id="debughelper">
-                <div id="debughelper_container">
-                    <button
-                        className="btn btn-default"
-                        onClick={this.showReportForm}
-                    >
-                        <Feedback style={{marginLeft: HelMaterialTheme.spacing(1)}}/>
-                    </button>
-                </div>
-                <div id="slide">Jos tapahtumien hallinnassa tai syöttölomakkeen toiminnassa on virhe, klikkaa {`"raportoi virhe"`}&#x2011;nappia,
-                    niin saamme virhetilanteesta tiedon ja voimme tutkia asiaa.</div>
-            </div>
-        </div>
-    }
-
-}
-
-ReactDOM.render(
-    <div>
-        <DebugHelper />
-    </div>,
-    document.getElementById('debughelper'));


### PR DESCRIPTION
Moved DebugHelper to components and changed it to be within 'content' div / removed it's own unnecessary div 'debughelper' from index.jade which was causing issues for other components & routing.