### PR TITLE
Material-UI Textfields to Form Inputs

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "axios": "^0.19.0",
     "body-parser": "^1.14.1",
     "bootstrap": "4.4.1",
-    "city_theme": "^0.2.0",
+    "city_theme": "^0.2.1",
     "classnames": "^2.2.6",
     "codecov": "^3.0.0",
     "cookie-parser": "^1.4.0",

--- a/src/components/FormFields/index.js
+++ b/src/components/FormFields/index.js
@@ -27,6 +27,8 @@ import OrganizationSelector from '../HelFormFields/OrganizationSelector';
 import UmbrellaSelector from '../HelFormFields/UmbrellaSelector/UmbrellaSelector'
 import moment from 'moment'
 import HelVideoFields from '../HelFormFields/HelVideoFields/HelVideoFields'
+// Removed material-ui/icons because it was no longer used.
+
 
 let FormHeader = (props) => (
     <div className="row">
@@ -403,6 +405,7 @@ class FormFields extends React.Component {
                 </FormHeader>
                 <div className="row">
                     <div className="col-sm-6">
+                        {/* Removed formatted message from label since it was causing accessibility issues */}
                         <HelTextField
                             validations={[VALIDATION_RULES.IS_URL]}
                             ref="extlink_facebook"

--- a/src/components/FormFields/index.js
+++ b/src/components/FormFields/index.js
@@ -182,7 +182,8 @@ class FormFields extends React.Component {
                             required={true}
                             multiLine={false}
                             label="event-headline"
-
+                            ref='name'
+                            name='name'
                             validationErrors={validationErrors['name', 'short_description']}
                             validations={[VALIDATION_RULES.SHORT_STRING]}
                             defaultValue={values['name']}

--- a/src/components/FormFields/index.js
+++ b/src/components/FormFields/index.js
@@ -18,7 +18,6 @@ import {
 } from 'src/components/HelFormFields'
 import RecurringEvent from 'src/components/RecurringEvent'
 import {Button,Form, FormGroup, Label, Input} from 'reactstrap';
-import {Add, Autorenew} from '@material-ui/icons'
 import {mapKeywordSetToForm, mapLanguagesSetToForm} from '../../utils/apiDataMapping'
 import {setEventData, setData} from '../../actions/editor'
 import {get, isNull, pickBy} from 'lodash'
@@ -28,7 +27,6 @@ import OrganizationSelector from '../HelFormFields/OrganizationSelector';
 import UmbrellaSelector from '../HelFormFields/UmbrellaSelector/UmbrellaSelector'
 import moment from 'moment'
 import HelVideoFields from '../HelFormFields/HelVideoFields/HelVideoFields'
-
 
 let FormHeader = (props) => (
     <div className="row">
@@ -184,7 +182,7 @@ class FormFields extends React.Component {
                             required={true}
                             multiLine={false}
                             label="event-headline"
-                            ref="name" name="name"
+
                             validationErrors={validationErrors['name', 'short_description']}
                             validations={[VALIDATION_RULES.SHORT_STRING]}
                             defaultValue={values['name']}
@@ -408,7 +406,7 @@ class FormFields extends React.Component {
                             validations={[VALIDATION_RULES.IS_URL]}
                             ref="extlink_facebook"
                             name="extlink_facebook"
-                            label={<FormattedMessage id="facebook-url"/>}
+                            label='Facebook'
                             validationErrors={validationErrors['extlink_facebook']}
                             defaultValue={values['extlink_facebook']}
                             setDirtyState={this.props.setDirtyState}
@@ -418,7 +416,7 @@ class FormFields extends React.Component {
                             validations={[VALIDATION_RULES.IS_URL]}
                             ref="extlink_twitter"
                             name="extlink_twitter"
-                            label={<FormattedMessage id="twitter-url"/>}
+                            label='Twitter'
                             validationErrors={validationErrors['extlink_twitter']}
                             defaultValue={values['extlink_twitter']}
                             setDirtyState={this.props.setDirtyState}
@@ -428,7 +426,7 @@ class FormFields extends React.Component {
                             validations={[VALIDATION_RULES.IS_URL]}
                             ref="extlink_instagram"
                             name="extlink_instagram"
-                            label={<FormattedMessage id="instagram-url"/>}
+                            label='Instagram'
                             validationErrors={validationErrors['extlink_instagram']}
                             defaultValue={values['extlink_instagram']}
                             setDirtyState={this.props.setDirtyState}

--- a/src/components/FormFields/index.scss
+++ b/src/components/FormFields/index.scss
@@ -31,13 +31,35 @@
     }
 }
 
-.place-id{
+.form-group {
+    h2 {
+        font-size: 20px !important;
+        margin-bottom: 1vh;
+    }
+    input {
+        border: none;
+        border-bottom: solid 2px;
+        border-radius: 0;
+        &:hover,
+        &:focus,
+        &:active {
+            box-shadow: none;
+            border-bottom: solid 3px;
+            border-color: #0072c6;
+        }
+    }
+}
+
+.place-id {
     margin-top: 10px;
     border-bottom-style:dashed;
     border-bottom-width: 2px;
     border-radius: 0px;
     border-color:rgb(84,84,84);
     font-size: 16px;
+    input {
+        border: none !important;
+    }
     .form-control:disabled, .form-control[readonly]{
         background-color: #fff;
         font-size: 16px;

--- a/src/components/FormFields/index.scss
+++ b/src/components/FormFields/index.scss
@@ -31,6 +31,7 @@
     }
 }
 
+// Styling for new Form Inputs
 .form-group {
     h2 {
         font-size: 20px !important;
@@ -50,6 +51,7 @@
     }
 }
 
+// Border: none to make sure there won't be any wierdness going on with .place-id, input field
 .place-id {
     margin-top: 10px;
     border-bottom-style:dashed;

--- a/src/components/HelFormFields/HelTextField.js
+++ b/src/components/HelFormFields/HelTextField.js
@@ -194,10 +194,10 @@ class HelTextField extends Component {
                         <Input 
                             id='title'
                             aria-labelledby='title'
-                            placeholder={label}
+                            placeholder={placeholder}
                             type='text'
                             name={name}
-                            defaulvalue={value}
+                            defaultValue={value}
                             required={required}
                             onChange={this.handleChange}
                             onBlur={this.handleBlur}

--- a/src/components/HelFormFields/HelTextField.js
+++ b/src/components/HelFormFields/HelTextField.js
@@ -1,11 +1,11 @@
 import PropTypes from 'prop-types';
-import React,{Fragment, Component} from 'react'
-
+import React,{Fragment, Component, useEffect, useState} from 'react'
+import {FormattedMessage} from 'react-intl'
 import {setData} from 'src/actions/editor.js'
-import {TextField} from '@material-ui/core'
 import validationRules from 'src/validation/validationRules';
 import ValidationPopover from 'src/components/ValidationPopover'
 import constants from '../../constants'
+import {Form, FormGroup, Label, Input, FormText} from 'reactstrap';
 
 
 const {VALIDATION_RULES, CHARACTER_LIMIT} = constants
@@ -186,32 +186,40 @@ class HelTextField extends Component {
             validationErrors,
             index,
             name,
-            multiLine,
+
         } = this.props
 
         return (
             <Fragment>
-                <TextField
-                    fullWidth
-                    name={name}
-                    label={label}
-                    value={value}
-                    required={required}
-                    placeholder={placeholder}
-                    disabled={disabled}
-                    onChange={this.handleChange}
-                    onBlur={this.handleBlur}
-                    multiline={multiLine}
-                    inputRef={ref => this.inputRef = ref}
-                    helperText={this.helpText()}
-                    InputLabelProps={{focused: false, shrink: false, disableAnimation: true}}
-                    error={this.state.error}
-                />
-                <ValidationPopover
-                    index={index}
-                    anchor={this.inputRef}
-                    validationErrors={validationErrors}
-                />
+                <Form>
+                    <FormGroup>
+                        
+                        <h2 title='title' >{label}</h2>
+                        <Input 
+                            id='title'
+                            aria-labelledby='title'
+                            placeholder={placeholder}
+                            type="text" 
+                            name={name}
+                            defaulvalue={value} 
+                            required={required}
+                            onChange={this.handleChange}
+                            onBlur={this.handleBlur}
+                            innerRef={ref => this.inputRef = ref}
+                            disabled={disabled}/>
+                       
+                                
+                        <FormText color="muted">
+                            {this.helpText()}
+                        </FormText>
+                        <ValidationPopover
+                            index={index}
+                            anchor={this.inputRef}
+                            validationErrors={validationErrors}
+                        />
+                    </FormGroup>
+                </Form> 
+                
             </Fragment>
         )
     }

--- a/src/components/HelFormFields/HelTextField.js
+++ b/src/components/HelFormFields/HelTextField.js
@@ -193,7 +193,6 @@ class HelTextField extends Component {
             <Fragment>
                 <Form>
                     <FormGroup>
-                        
                         <h2 title='title' >{label}</h2>
                         <Input 
                             id='title'
@@ -201,14 +200,12 @@ class HelTextField extends Component {
                             placeholder={placeholder}
                             type="text" 
                             name={name}
-                            defaulvalue={value} 
+                            defaulValue={value} 
                             required={required}
                             onChange={this.handleChange}
                             onBlur={this.handleBlur}
                             innerRef={ref => this.inputRef = ref}
                             disabled={disabled}/>
-                       
-                                
                         <FormText color="muted">
                             {this.helpText()}
                         </FormText>

--- a/src/components/HelFormFields/HelTextField.js
+++ b/src/components/HelFormFields/HelTextField.js
@@ -5,6 +5,7 @@ import validationRules from 'src/validation/validationRules';
 import ValidationPopover from 'src/components/ValidationPopover'
 import constants from '../../constants'
 import {Form, FormGroup, Input, FormText} from 'reactstrap';
+// Removed material-ui/core since it's no longer in use
 
 const {VALIDATION_RULES, CHARACTER_LIMIT} = constants
 
@@ -175,6 +176,7 @@ class HelTextField extends Component {
 
     render () {
         const {value} = this.state
+        // Removed multiLine since it was no longer used
         const {
             required,
             disabled,
@@ -183,9 +185,9 @@ class HelTextField extends Component {
             validationErrors,
             index,
             name,
-
         } = this.props
 
+        // Replaced TextField component with Form/FormGroup + Input, to make inputs actually accessible and customizable.
         return (
             <Fragment>
                 <Form>

--- a/src/components/HelFormFields/HelTextField.js
+++ b/src/components/HelFormFields/HelTextField.js
@@ -190,14 +190,14 @@ class HelTextField extends Component {
             <Fragment>
                 <Form>
                     <FormGroup>
-                        <h2 title='title' >{label}</h2>
+                        <h2 tabIndex='0' >{label}</h2>
                         <Input 
                             id='title'
-                            aria-labelledby='title'
+                            aria-labelledby='title'                          
                             placeholder={placeholder}
                             type='text'
                             name={name}
-                            defaultValue={value}
+                            defaulvalue={value}
                             required={required}
                             onChange={this.handleChange}
                             onBlur={this.handleBlur}

--- a/src/components/HelFormFields/HelTextField.js
+++ b/src/components/HelFormFields/HelTextField.js
@@ -1,12 +1,10 @@
 import PropTypes from 'prop-types';
-import React,{Fragment, Component, useEffect, useState} from 'react'
-import {FormattedMessage} from 'react-intl'
+import React,{Fragment, Component} from 'react'
 import {setData} from 'src/actions/editor.js'
 import validationRules from 'src/validation/validationRules';
 import ValidationPopover from 'src/components/ValidationPopover'
 import constants from '../../constants'
-import {Form, FormGroup, Label, Input, FormText} from 'reactstrap';
-
+import {Form, FormGroup, Input, FormText} from 'reactstrap';
 
 const {VALIDATION_RULES, CHARACTER_LIMIT} = constants
 
@@ -141,7 +139,6 @@ class HelTextField extends Component {
                 return validations;
             }
         }
-
         return []
     }
     
@@ -197,16 +194,16 @@ class HelTextField extends Component {
                         <Input 
                             id='title'
                             aria-labelledby='title'
-                            placeholder={placeholder}
-                            type="text" 
+                            placeholder={label}
+                            type='text'
                             name={name}
-                            defaulValue={value} 
+                            defaulvalue={value}
                             required={required}
                             onChange={this.handleChange}
                             onBlur={this.handleBlur}
                             innerRef={ref => this.inputRef = ref}
                             disabled={disabled}/>
-                        <FormText color="muted">
+                        <FormText color='muted'>
                             {this.helpText()}
                         </FormText>
                         <ValidationPopover
@@ -215,8 +212,7 @@ class HelTextField extends Component {
                             validationErrors={validationErrors}
                         />
                     </FormGroup>
-                </Form> 
-                
+                </Form>
             </Fragment>
         )
     }

--- a/src/views/Editor/index.scss
+++ b/src/views/Editor/index.scss
@@ -4,79 +4,62 @@ $actionBtnHeight: 60px;
 .editor-page {
     font-weight: 300;
     background-color: #ffffff;
-
     .header {
         align-items: baseline;
         display: flex;
         position: relative;
-
         .controls {
             margin-left: auto;
-
             button:not(:first-of-type) {
                 margin-left: 15px;
             }
         }
     }
-
     h2,h3,legend,.legend {
         font-family: "HelsinkiGrotesk", "Roboto", "Helvetica Neue", "Segoe UI", Calibri, sans-serif;
     }
-
     h2,h3 {
         margin-top: 55px;
     }
-
     .highlighted-block {
         display: block;
         background-color: #f6f6f6;
         padding: 20px;
-
         //line-height: 72px;
         line-height: 1.5;
-
         color: #5a5959;
-
         label {
             font-size: 24px;
             margin-bottom: 0;
             line-height: 1.5;
         }
-
         .language-selection {
             height: 100%;
             width: 100%;
             display: flex;
             justify-content: space-around;
             flex-wrap: wrap;
-
             & > * {
                 flex: 0 1 33%;
                 margin: 0;
             }
         }
     }
-
     .side-field {
         padding-top: 36px;
-
         p {
             font-size: 18px;
             font-weight: 300;
             color: #373a3c;
         }
-
         strong {
             font-weight: bold;
         }
-
         &.padded {
             padding-top: 66px;
         }
-
         &-umbrella {
             padding-top: 0;
-
             .tip {
                 margin-top: 0;
             }
@@ -86,7 +69,6 @@ $actionBtnHeight: 60px;
     .hel-select {
         display: block;
         clear: both;
-
         legend,
         .legend {
             font-size: 24px;
@@ -103,25 +85,20 @@ $actionBtnHeight: 60px;
         margin-top: 3rem;
         padding-top: 2rem;
         position: relative;
-
         .loading-spinner {
             position: absolute;
         }
-
         .buttons-group {
             display: flex;
             flex-wrap: wrap;
             justify-content: flex-end;
-
             button {
                 height: $actionBtnHeight;
             }
-
             > * {
                 &:not(:first-child) {
                     margin-left: 15px;
                 }
-
                 &.editor-delete-button {
                     margin-right: auto;
                 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2407,10 +2407,10 @@ cipher-base@^1.0.0, cipher-base@^1.0.1, cipher-base@^1.0.3:
     inherits "^2.0.1"
     safe-buffer "^5.0.1"
 
-city_theme@^0.2.0:
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/city_theme/-/city_theme-0.2.0.tgz#c075ec36af952046352e08801e0ccc372d531ce6"
-  integrity sha512-3MNqtFSAh4hBiJSvedUXfKTRUIVPctMS6Q/PSbBzUQTi7HpxAzW3YwR2pLNU8515by1x9qjEusPybR3YutAYQg==
+city_theme@^0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/city_theme/-/city_theme-0.2.1.tgz#e188febe911a1b085babc5d66ab3b8dc65ad3ea5"
+  integrity sha512-e9pfMqniIRZLRdY32D+v/nRwCLPmxPggIKvrgogCjd2O9yB7Up9/bOXRIeR8e4/8eOsmNjXa8ammAxku3PNr/w==
 
 class-utils@^0.3.5:
   version "0.3.6"


### PR DESCRIPTION
Changing 'create a new event' page to have more accessible input components with more customizable options.

There's still some unnecessary clutter (functions and props), which needs to be removed/cleaned out later.