### PR TITLE
fix/LIN74

### DIFF
--- a/src/components/FormFields/index.js
+++ b/src/components/FormFields/index.js
@@ -206,6 +206,7 @@ class FormFields extends React.Component {
                             validations={[VALIDATION_RULES.SHORT_STRING]}
                             setDirtyState={this.props.setDirtyState}
                             forceApplyToStore
+                            type='textarea'
                         />
 
                         <MultiLanguageField
@@ -220,6 +221,7 @@ class FormFields extends React.Component {
                             languages={this.props.editor.contentLanguages}
                             validations={[VALIDATION_RULES.LONG_STRING]}
                             setDirtyState={this.props.setDirtyState}
+                            type='textarea'
                         />
                         <MultiLanguageField
                             id='event-info-url'
@@ -234,6 +236,7 @@ class FormFields extends React.Component {
                             validations={[VALIDATION_RULES.IS_URL]}
                             setDirtyState={this.props.setDirtyState}
                             forceApplyToStore
+                            type='text'
                         />
                         <MultiLanguageField
                             id='event-provider-input'
@@ -246,6 +249,7 @@ class FormFields extends React.Component {
                             defaultValue={values['provider']}
                             languages={this.props.editor.contentLanguages}
                             setDirtyState={this.props.setDirtyState}
+                            type='text'
                         />
                         <OrganizationSelector
                             formType={formType}
@@ -373,6 +377,7 @@ class FormFields extends React.Component {
                             defaultValue={values['location_extra_info']}
                             languages={this.props.editor.contentLanguages}
                             setDirtyState={this.props.setDirtyState}
+                            type='text'
                         />
                     </div>
                     <SideField>
@@ -423,6 +428,7 @@ class FormFields extends React.Component {
                             defaultValue={values['extlink_facebook']}
                             setDirtyState={this.props.setDirtyState}
                             forceApplyToStore
+                            type='text'
                         />
                         <HelTextField
                             validations={[VALIDATION_RULES.IS_URL]}
@@ -434,6 +440,7 @@ class FormFields extends React.Component {
                             defaultValue={values['extlink_twitter']}
                             setDirtyState={this.props.setDirtyState}
                             forceApplyToStore
+                            type='text'
                         />
                         <HelTextField
                             validations={[VALIDATION_RULES.IS_URL]}
@@ -445,6 +452,7 @@ class FormFields extends React.Component {
                             defaultValue={values['extlink_instagram']}
                             setDirtyState={this.props.setDirtyState}
                             forceApplyToStore
+                            type='text'
                         />
                     </div>
                     <SideField><p className="tip"><FormattedMessage id="editor-tip-social-media"/></p></SideField>
@@ -508,6 +516,7 @@ class FormFields extends React.Component {
                                     validationErrors={validationErrors['audience_min_age']}
                                     defaultValue={values['audience_min_age']}
                                     setDirtyState={this.props.setDirtyState}
+                                    type='text'
                                 />
 
                                 <HelTextField
@@ -517,6 +526,7 @@ class FormFields extends React.Component {
                                     validationErrors={validationErrors['audience_max_age']}
                                     defaultValue={values['audience_max_age']}
                                     setDirtyState={this.props.setDirtyState}
+                                    type='text'
                                 />
                             </div>
                         </div>
@@ -555,6 +565,7 @@ class FormFields extends React.Component {
                                     validationErrors={validationErrors['minimum_attendee_capacity']}
                                     defaultValue={values['minimum_attendee_capacity']}
                                     setDirtyState={this.props.setDirtyState}
+                                    type='text'
                                 />
 
                                 <HelTextField
@@ -564,6 +575,7 @@ class FormFields extends React.Component {
                                     validationErrors={validationErrors['maximum_attendee_capacity']}
                                     defaultValue={values['maximum_attendee_capacity']}
                                     setDirtyState={this.props.setDirtyState}
+                                    type='text'
                                 />
                             </div>
                         </div>

--- a/src/components/FormFields/index.scss
+++ b/src/components/FormFields/index.scss
@@ -38,9 +38,9 @@ textarea {
 
 // Styling for new Form Inputs
 .event-input {
-    h2 {
-        font-size: 20px !important;
-        margin-bottom: 1vh;
+    label {
+        font-size: 20px;
+        padding-top: 2vh;
     }
     input {
         border: none;
@@ -51,6 +51,16 @@ textarea {
         &:active {
             box-shadow: none;
             border-bottom: solid 3px;
+            border-color: #0072c6;
+        }
+    }
+    textarea {
+        border: solid 2px;
+        &:hover,
+        &:focus,
+        &:active {
+            box-shadow: none;
+            border: solid 3px;
             border-color: #0072c6;
         }
     }

--- a/src/components/FormFields/index.scss
+++ b/src/components/FormFields/index.scss
@@ -8,6 +8,11 @@
     }
 }
 
+// disables horizontal resizing for the description textareas
+textarea {
+    resize: vertical;
+}
+
 .clipboard-copy-button {
     padding: 3px;
     position: absolute;

--- a/src/components/HelFormFields/HelTextField.js
+++ b/src/components/HelFormFields/HelTextField.js
@@ -174,14 +174,6 @@ class HelTextField extends Component {
         return (errors.length === 0)
     }
 
-    getUniqueId() {
-        const {label} = this.props;
-
-        const randomNumber = Math.floor(Math.random() * (1000 - 100 + 1) + 100);
-        const str = (typeof label === 'string' && label.length > 1) ? label.slice(0,2) : 'id';
-        return str + randomNumber.toString();
-    }
-
     render () {
         const {value} = this.state
         // Removed multiLine since it was no longer used
@@ -195,6 +187,7 @@ class HelTextField extends Component {
             name,
         } = this.props
         const fieldID = this.props.id;
+        const type = this.props.type;
 
         // Replaced TextField component with Form/FormGroup + Input, to make inputs actually accessible and customizable.
         return (
@@ -204,9 +197,9 @@ class HelTextField extends Component {
                     <Input
                         id={fieldID}
                         placeholder={placeholder}
-                        type='text'
+                        type={type}
                         name={name}
-                        defaulvalue={value}
+                        value={value}
                         required={required}
                         onChange={this.handleChange}
                         onBlur={this.handleBlur}
@@ -254,5 +247,9 @@ HelTextField.propTypes = {
     maxLength: PropTypes.number,
     id: PropTypes.string,
 }
+
+HelTextField.defaultProps = {
+    type: 'text',
+};
 
 export default HelTextField

--- a/src/components/HelFormFields/MultiLanguageField.js
+++ b/src/components/HelFormFields/MultiLanguageField.js
@@ -48,6 +48,7 @@ class MultiLanguageField extends React.Component {
         multiLine: PropTypes.bool,
         label: PropTypes.string,
         id: PropTypes.string,
+        type: PropTypes.string,
     }
 
     onChange(e,value,lang) {
@@ -137,7 +138,10 @@ class MultiLanguageField extends React.Component {
                         validations={this.props.validations}
                         validationErrors={this.props.validationErrors}
                         index={this.props.index}
-                        multiLine={this.props.multiLine} />
+                        multiLine={this.props.multiLine}
+                        type={this.props.type}
+                    />
+
                 </div>
             )
         } else {
@@ -155,6 +159,7 @@ class MultiLanguageField extends React.Component {
                             onBlur={(e,v) => this.onBlur(e,v)}
                             disabled={this.props.disabled}
                             validations={this.props.validations}
+                            type={this.props.type}
                         />
                     </div>
                 )
@@ -179,5 +184,9 @@ class MultiLanguageField extends React.Component {
     }
 
 }
+
+MultiLanguageField.defaultProps = {
+    type: 'text',
+};
 
 export default MultiLanguageField


### PR DESCRIPTION
fix so that event data shows up in the form when editing,type prop(string) for the input is now passed from FormFields/index -> MultiLanguageField -> HelTextField. ie type='text' / type='textarea'.
Added 'textarea' type for the description fields, removed old getUniqueID method from HelTextField as it is no longer used.