### PR TITLE
Changed welcome text

### DIFF
--- a/src/views/App/index.js
+++ b/src/views/App/index.js
@@ -127,11 +127,10 @@ class App extends React.Component {
                     >
                         <h4>Tervetuloa käyttämään Linked Eventsiä, {this.props.user.displayName}!</h4>
                         <p>Sinulla ei ole vielä oikeutta hallinnoida yhdenkään yksikön tapahtumia.
-                        Ota yhteyttä <a href="mailto:paavo.jantunen@hel.fi">Paavo Jantuseen</a> saadaksesi oikeudet
+                        Ota yhteyttä <a href="mailto:matias.peltonen@turku.fi">Matias Peltoseen</a> saadaksesi oikeudet
                         muokata yksikkösi tapahtumia.</p>
                         <p>Jos olet jo saanut käyttöoikeudet, kirjautumisesi saattaa olla vanhentunut. Kokeile sivun
                         päivittämistä (F5) ja kirjautumista uudestaan.</p>
-                        <p>Helsinki Marketingin yhteistyökumppanit: <a href="mailto:toni.uuttu@hel.fi">Toni Uuttu</a></p>
                     </Paper>
             }
         }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2415,10 +2415,10 @@ cipher-base@^1.0.0, cipher-base@^1.0.1, cipher-base@^1.0.3:
     inherits "^2.0.1"
     safe-buffer "^5.0.1"
 
-city_theme@^0.2.1:
-  version "0.2.1"
-  resolved "https://registry.yarnpkg.com/city_theme/-/city_theme-0.2.1.tgz#e188febe911a1b085babc5d66ab3b8dc65ad3ea5"
-  integrity sha512-e9pfMqniIRZLRdY32D+v/nRwCLPmxPggIKvrgogCjd2O9yB7Up9/bOXRIeR8e4/8eOsmNjXa8ammAxku3PNr/w==
+city_theme@^0.2.3:
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/city_theme/-/city_theme-0.2.3.tgz#98adc773f2c7ff830358b50b0fba7f2c26fd18cc"
+  integrity sha512-EcslB/WddR6yj/b/PHn3asGOQLjAU1Fbqnk2RDsF/6lLsqVE0cSXSjPYNoOfgpw+MXP+3YiPLjMKja/hmjTnEg==
 
 class-utils@^0.3.5:
   version "0.3.6"


### PR DESCRIPTION
Changed our side of welcome text to reflect our own needs.
In the long run we want this text to come from somewhere else ( probably theme package etc ) but for testing purposes, I think this temporary fix is good enough.

So in this case, we want @pelmat to handle permit requests.

Also it appears that our yarn.lock has updated to our latest city_theme.