### PR TITLE
cookieBar link

### DIFF
--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -362,5 +362,5 @@
 	"cookieBar.decline.url": "https://www.google.com/",
 	"cookieBar.description": "We use cookies to improve your browsing experience. By continuing to use Linked Events, you accept the use of cookies.",
 	"cookieBar.link.text": "Link to cookie policy",
-	"cookieBar.link.url": "https://www.google.com/"
+	"cookieBar.link.url": "https://testilinkedevents.turku.fi/cookie-policy/info-en.html"
 }

--- a/src/i18n/fi.json
+++ b/src/i18n/fi.json
@@ -370,7 +370,7 @@
 	"cookieBar.decline.url": "https://www.google.fi/",
 	"cookieBar.description": "Käytämme evästeitä parantaaksemme käyttökokemustasi. Jatkamalla Linked Events käyttöä hyväksyt evästeiden käytön.",
 	"cookieBar.link.text": "Linkki evästekäytäntöön",
-    "cookieBar.link.url": "https://www.google.fi/",
+    "cookieBar.link.url": "https://testilinkedevents.turku.fi/cookie-policy/info-fi.html",
     
     "footer-accessibility": "Saavutettavuusseloste",
     "footer-city": "© Helsingin kaupunki",

--- a/src/i18n/sv.json
+++ b/src/i18n/sv.json
@@ -355,5 +355,5 @@
 	"cookieBar.decline.url": "https://www.google.se/",
 	"cookieBar.description": "Vi använder cookies för att kunna ge dig en bättre upplevelse. Genom att du fortsätter att använda Linked Events så accepterar du användingen av cookies.",
 	"cookieBar.link.text": "Länk till Cookie Policy",
-	"cookieBar.link.url": "https://www.google.se/"
+	"cookieBar.link.url": "https://testilinkedevents.turku.fi/cookie-policy/info-sv.html"
 }


### PR DESCRIPTION
Changed cookieBar.link.url to redirect to our User information and Cookies in the service Linked Events page.