### PR TITLE
Changed date picker for end dates to open at a better date

### DIFF
--- a/src/components/CustomFormFields/CustomDatePicker.js
+++ b/src/components/CustomFormFields/CustomDatePicker.js
@@ -33,6 +33,7 @@ class CustomDatePicker extends React.Component {
         this.getCorrectInputLabel = this.getCorrectInputLabel.bind(this)
         this.getCorrectMinDate = this.getCorrectMinDate.bind(this)
         this.roundDateToCorrectUnit = this.roundDateToCorrectUnit.bind(this)
+        this.getDatePickerOpenDate = this.getDatePickerOpenDate.bind(this)
     }
 
     static contextTypes = {
@@ -153,6 +154,16 @@ class CustomDatePicker extends React.Component {
             return new Date()
     }
 
+    // returns the date DatePicker will show as selected when calendar is opened
+    getDatePickerOpenDate(defaultValue, minDate){
+        if(defaultValue)
+            return new Date(defaultValue)
+        else if(minDate)
+            return new Date(minDate)
+        else
+            return new Date(this.roundDateToCorrectUnit(moment()))
+    }
+
     componentDidUpdate(prevProps) {
         // Update validation if min or max date changes and state.inputValue is not empty
         const {minDate, maxDate, type} = this.props
@@ -164,7 +175,6 @@ class CustomDatePicker extends React.Component {
 
     render(){
         const {label, name, id, defaultValue, minDate, maxDate, type, disabled} = this.props
-        const date = defaultValue ? new Date(defaultValue) : new Date()
         const inputValue = this.state.inputValue
         const inputErrorId = 'date-input-error__' + id
         return(
@@ -185,7 +195,7 @@ class CustomDatePicker extends React.Component {
                         />
                         <DatePicker
                             disabled={disabled}
-                            selected={date}
+                            openToDate={this.getDatePickerOpenDate(defaultValue, minDate)}
                             onChange={this.handleDatePickerChange}
                             customInput={<DatePickerButton disabled={disabled}/>}
                             minDate={this.getCorrectMinDate(minDate)}

--- a/src/components/CustomFormFields/tests/CustomDatePicker.test.js
+++ b/src/components/CustomFormFields/tests/CustomDatePicker.test.js
@@ -90,7 +90,7 @@ describe('CustomDatePicker', () => {
                 const datePicker = wrapper.find(DatePicker)
                 expect(datePicker).toHaveLength(1);
                 expect(datePicker.prop('disabled')).toBe(defaultProps.disabled)
-                expect(datePicker.prop('selected')).toBeDefined()
+                expect(datePicker.prop('openToDate')).toBeDefined()
                 expect(datePicker.prop('onChange')).toBe(instance.handleDatePickerChange)
                 expect(datePicker.prop('customInput')).toEqual(<DatePickerButton disabled={defaultProps.disabled}/>)
                 expect(datePicker.prop('minDate')).toBe(instance.getCorrectMinDate(defaultProps.minDate))
@@ -110,12 +110,6 @@ describe('CustomDatePicker', () => {
                         boundariesElement: 'viewport',
                     },
                 })
-            })
-
-            test('prop selected is correct Date when props.defaultValue is defined', () => {
-                const defaultValue = moment().startOf('minute')
-                const datePicker = getWrapper({defaultValue}).find(DatePicker)
-                expect(datePicker.prop('selected')).toEqual(defaultValue.toDate())
             })
 
             test('prop maxDate is correct Date when props.maxDate is defined', () => {
@@ -325,6 +319,30 @@ describe('CustomDatePicker', () => {
                 const minDate = moment().subtract(1, 'day')
                 const returnValue = instance.getCorrectMinDate(minDate, true)
                 expect(moment(returnValue).startOf('hour').toString()).toEqual(moment().startOf('hour').toString())
+            })
+        })
+
+        describe('getDatePickerOpenDate', () => {
+            const instance = getWrapper().instance()
+
+            test('returns defaultValue if it is defined', () => {
+                const defaultValue = moment()
+                const minDate = defaultValue.subtract(1, 'days');
+                expect(instance.getDatePickerOpenDate(defaultValue, minDate)).toEqual(new Date(defaultValue))
+            })
+
+            test('returns minDate if it is defined and defaultValue is not defined', () => {
+                const defaultValue = undefined
+                const minDate = moment()
+                expect(instance.getDatePickerOpenDate(defaultValue, minDate)).toEqual(new Date(minDate))
+            })
+
+            test('returns new date if defaultValue and minDate are not defined', () => {
+                const defaultValue = undefined
+                const minDate = undefined
+                expect(instance.getDatePickerOpenDate(defaultValue, minDate)).toEqual(
+                    new Date(instance.roundDateToCorrectUnit(moment()))
+                )
             })
         })
 

--- a/src/components/SearchBar/index.js
+++ b/src/components/SearchBar/index.js
@@ -17,7 +17,7 @@ const handleKeyPress = (event, startDate, endDate, onFormSubmit, setSearchQuery)
 };
 
 const SearchBar = ({intl, onFormSubmit}) => {
-    const [startDate, setStartDate] = useState(moment());
+    const [startDate, setStartDate] = useState(moment().startOf('day'));
     const [endDate, setEndDate] = useState(null);
     const [searchQuery, setSearchQuery] = useState('');
 


### PR DESCRIPTION
Date pickers for end dates will now open at the same date as start date if end date hasn't been selected yet.