### PR TITLE
Streamlining mobile looks

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "axios": "^0.19.0",
     "body-parser": "^1.14.1",
     "bootstrap": "4.4.1",
-    "city_theme": "^0.5.0",
+    "city_theme": "^0.5.6",
     "classnames": "^2.2.6",
     "codecov": "^3.0.0",
     "cookie-parser": "^1.4.0",

--- a/src/assets/main.scss
+++ b/src/assets/main.scss
@@ -205,12 +205,12 @@ h2 {
 @media (max-width: 480px) {
     h1 {
         font-size: 37px;
-        padding-top: 40px;
-        padding-bottom: 40px;
+        padding-top: 20px;
+        padding-bottom: 20px;
     }
     h2 {
-        padding-top: 40px;
-        padding-bottom: 40px;
+        padding-top: 20px;
+        padding-bottom: 20px;
     }
     #debughelper {
         bottom: 1em;

--- a/src/components/HelFormFields/HelLanguageSelect.js
+++ b/src/components/HelFormFields/HelLanguageSelect.js
@@ -32,7 +32,6 @@ class HelLanguageSelect extends React.Component {
 
             return (
                 <Form key={index}>
-                    <Label className='language-selection' htmlFor={`checkBox-${item.value}`}><FormattedMessage id={item.label}/></Label>
                     <Input
                         id={`checkBox-${item.value}`}
                         className='checkbox1'
@@ -43,8 +42,9 @@ class HelLanguageSelect extends React.Component {
                         checked={isChecked}
                         disabled={disabled}
                         onChange={this.onChange}
-                        aria-checked='mixed'
+                        aria-checked={isChecked}
                     />   
+                    <Label className='language-selection' htmlFor={`checkBox-${item.value}`}><FormattedMessage id={item.label}/></Label>
                 </Form>
             )
         })

--- a/src/components/RecurringEvent/RecurringEvent.scss
+++ b/src/components/RecurringEvent/RecurringEvent.scss
@@ -7,11 +7,14 @@
     .modal-header {
         padding-left: 24px;
         padding-right: 24px;
+        align-items: center;
         .modal-title {
             margin-top: 0px !important;
             display: flex;
             flex: auto;
             justify-content: space-between;
+            font-size: 1.25rem;
+            font-weight: 500;
         }
         button {
             color: black;
@@ -34,6 +37,11 @@
         .col-sm-12 {
         h2 {
             margin-top: 0px !important;
+            font-weight: 500;
+            font-size: 1.25rem;
+        }
+        h3 {
+            font-size: 1.25rem;
         }
         button {
             width: 100%;

--- a/src/views/Editor/index.scss
+++ b/src/views/Editor/index.scss
@@ -30,7 +30,7 @@ $actionBtnHeight: 60px;
         color: #5a5959;
         label {
             font-size: 24px;
-            line-height: 2.5; 
+            line-height: 1.5; 
         }
         .language-selection {
             height: 0.1%;
@@ -119,10 +119,20 @@ $actionBtnHeight: 60px;
 @media (max-width: 480px) {
     legend,
         .legend  {
-        margin-top: 2rem !important;
+        margin-top: 1rem !important;
     }
     .editor-page {
+        .highlighted-block {
+        .language-selection{
+            display: inline-block;
+            .checkbox1 {
+                vertical-align: text-bottom;
+                position: relative !important;
+            }
+        }
+    }
     .editor-action-buttons {
+        height: auto;
         .buttons-group {
             display: block;
             .btn-secondary {
@@ -136,13 +146,52 @@ $actionBtnHeight: 60px;
         }
     }
     
-}}
-@media (max-width: 780px) {
+}}}
+@media (min-width: 480px) and (max-width: 780px) {
     .editor-page {
+        .editor-action-buttons {
+            height: auto;
+            .buttons-group {
+                display: grid;
+                justify-content: normal !important;
+                button {
+                    width: 100%;
+                    margin: 0.3vh;
+                }
+                            > * {
+                &:not(:first-child) {
+                    margin-left: 0px;
+                }
+        }
+    }
+    }
         .highlighted-block {
             .language-selection {
-                display: contents;
+                display: inline-block;
+                    .checkbox1 {
+                        vertical-align: text-bottom;
+                        position: relative !important;
+                    }
             }
         }
     }
-}}
+}
+@media (max-width: 1200px) and (min-width: 768px) {
+    .editor-page {
+    .editor-action-buttons{
+        height: auto;
+    .buttons-group {
+    display: grid !important;
+    text-align: center;
+    justify-content: normal !important;
+    *:not(:first-child) {
+        margin-left: 0px;
+    }
+    button {
+        width: 100%;
+        margin-bottom: 0.3vh;
+    }
+}
+    }
+}
+}

--- a/src/views/Event/index.scss
+++ b/src/views/Event/index.scss
@@ -55,6 +55,8 @@
 
     .event-actions {
         width: 100%;
+        padding-right: 15px;
+        padding-left: 15px;
     }
 }
 
@@ -84,6 +86,14 @@
     }
     .event-actions {
         display: grid !important;
+        .cancel-delete-btn,
+        .edit-copy-btn {
+    
+            > *:not(:last-child) {
+                margin-right: 0px;
+            }
+        }
+
     button {
         margin-bottom: 10px;
         line-height: 1.5;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2415,10 +2415,10 @@ cipher-base@^1.0.0, cipher-base@^1.0.1, cipher-base@^1.0.3:
     inherits "^2.0.1"
     safe-buffer "^5.0.1"
 
-city_theme@^0.5.0:
-  version "0.5.0"
-  resolved "https://registry.yarnpkg.com/city_theme/-/city_theme-0.5.0.tgz#6f91e38f105eb96fa495c3dd6021bd4df3d9ca33"
-  integrity sha512-iybfSIlZpMo7Yw1U4+EyL+Wj1SvHOUr/g9szLuVOZCdJ/uXxnKMtXDbABSpk6PeU7eKMYgUdn+NKeAMPEylgEw==
+city_theme@^0.5.6:
+  version "0.5.6"
+  resolved "https://registry.yarnpkg.com/city_theme/-/city_theme-0.5.6.tgz#46331f3237793e565fbdd558e41cf1fa1e343587"
+  integrity sha512-Jc04F23p+gMkWjvdINbXnwxQEe7EOa56Wbl7xhTcEuBqQrTynn6w9WacbiOFXkIztGZjAn3JgG4tHCYtKFmm6Q==
 
 class-utils@^0.3.5:
   version "0.3.6"


### PR DESCRIPTION
Changed in main.scss, paddings for headers in mobile for tighter look.

Changed events selection in which language event would be presented, switched Labels position from above input to under it for better look in mobile & changed aria-checked from mixed to isChecked.

Changed recurringEvents modals layout to more streamline.

in editor changed language checkboxes styling little bit to match changes in HelLanguageSelect

Changed legends margin in mobile for tighter look.

Changed action buttons tyling overall in different views(moderator, regular user etc) to be more streamlined and not leak over the page.