### PR TITLE
Changed date time fields label parameter in events form

### DIFF
--- a/src/components/CustomFormFields/CustomDateTimeField.js
+++ b/src/components/CustomFormFields/CustomDateTimeField.js
@@ -78,7 +78,7 @@ CustomDateTimeField.propTypes = {
     eventKey: PropTypes.string,
     defaultValue: PropTypes.string,
     setDirtyState: PropTypes.func,
-    label: PropTypes.string.isRequired,
+    label: PropTypes.oneOfType([PropTypes.string, PropTypes.object]).isRequired,
     validationErrors: PropTypes.oneOfType([
         PropTypes.array,
         PropTypes.object,

--- a/src/components/FormFields/index.js
+++ b/src/components/FormFields/index.js
@@ -279,7 +279,7 @@ class FormFields extends React.Component {
                                     validationErrors={validationErrors['start_time']}
                                     defaultValue={values['start_time']}
                                     name="start_time"
-                                    label="event-starting-datetime"
+                                    label={<FormattedMessage  id="event-starting-datetime" />}
                                     setDirtyState={this.props.setDirtyState}
                                     maxDate={values['end_time'] ? moment(values['end_time']) : undefined}
                                 />
@@ -292,7 +292,7 @@ class FormFields extends React.Component {
                                     validationErrors={validationErrors['end_time']}
                                     defaultValue={values['end_time']}
                                     name="end_time"
-                                    label="event-ending-datetime"
+                                    label={<FormattedMessage  id="event-ending-datetime" />}
                                     setDirtyState={this.props.setDirtyState}
                                     minDate={values['start_time'] ? moment(values['start_time']) : undefined}
                                 />

--- a/src/components/HelFormFields/NewEvent.js
+++ b/src/components/HelFormFields/NewEvent.js
@@ -6,6 +6,7 @@ import {connect} from 'react-redux'
 import {deleteSubEvent as deleteSubEventAction} from 'src/actions/editor'
 import {IconButton, withStyles} from '@material-ui/core'
 import {Delete} from '@material-ui/icons'
+import {FormattedMessage} from 'react-intl'
 
 const DeleteButton = withStyles(theme => ({
     root: {
@@ -26,7 +27,7 @@ const NewEvent = ({event, eventKey, errors, deleteSubEvent}) => (
             <CustomDateTimeField
                 id={'start_time' + eventKey}
                 name="start_time"
-                label="event-starting-datetime"
+                label={<FormattedMessage  id="event-starting-datetime" />}
                 defaultValue={event.start_time}
                 eventKey={eventKey}
                 validationErrors={errors['start_time']}
@@ -35,7 +36,7 @@ const NewEvent = ({event, eventKey, errors, deleteSubEvent}) => (
                 disablePast
                 id={'end_time' + eventKey}
                 name="end_time"
-                label="event-ending-datetime"
+                label={<FormattedMessage  id="event-ending-datetime" />}
                 defaultValue={event.end_time}
                 eventKey={eventKey}
                 validationErrors={errors['end_time']}


### PR DESCRIPTION
Date time fields in events form now take FormattedMessage as label instead of only translation id string.

This change allows date picker to update itself and its label on language change.