### PR TITLE
replaced material-ui tooltip with reactstrap tooltip

### DIFF
--- a/src/assets/main.scss
+++ b/src/assets/main.scss
@@ -39,7 +39,7 @@ html, body {
     height: 100%;
     display: flex;
     flex-direction: column;
-}	
+}
 
 h1,h2,h3 {
     font-family: "HelsinkiGrotesk", "Roboto", "Helvetica Neue", "Segoe UI", Calibri, sans-serif;
@@ -208,7 +208,7 @@ h2 {
             }
             }
         }
-    
+
 .organization-missing-msg {
     margin: 3rem 1rem 0rem 1rem;
     padding: 1rem;
@@ -242,5 +242,18 @@ h2 {
             margin-top: 0rem;
         }
     }
+}
+
+// Reactstrap Tooltip component styles
+.tooltip-disabled {
+    color: #fff;
+    padding: 4px 8px;
+    //font-size: 0.625rem;
+    max-width: 400px;
+    word-wrap: break-word;
+    font-weight: 500;
+    line-height: 1.4em;
+    border-radius: 4px;
+    background-color: rgba(97, 97, 97, 0.9);
 }
 

--- a/src/assets/main.scss
+++ b/src/assets/main.scss
@@ -248,12 +248,11 @@ h2 {
 .tooltip-disabled {
     color: #fff;
     padding: 4px 8px;
-    //font-size: 0.625rem;
     max-width: 400px;
     word-wrap: break-word;
     font-weight: 500;
     line-height: 1.4em;
     border-radius: 4px;
-    background-color: rgba(97, 97, 97, 0.9);
+    background-color: black;
 }
 

--- a/src/components/EventActionButton/EventActionButton.js
+++ b/src/components/EventActionButton/EventActionButton.js
@@ -109,7 +109,7 @@ class EventActionButton extends React.Component {
                 }
                 <Button
                     aria-disabled={disabled}
-                    aria-label={(disabled && explanationId) ? intl.formatMessage({id: explanationId}) : null}
+                    aria-label={disabled && explanationId && `${intl.formatMessage({id: buttonLabel})}. ${intl.formatMessage({id: explanationId})}`}
                     id={action}
                     color={color}
                     className={classNames(`editor-${action}-button`,{'disabled': disabled})}

--- a/src/components/EventActionButton/EventActionButton.js
+++ b/src/components/EventActionButton/EventActionButton.js
@@ -7,9 +7,7 @@ import {checkEventEditability} from '../../utils/checkEventEditability';
 import constants from '../../constants';
 import showConfirmationModal from '../../utils/confirm';
 import {appendEventDataWithSubEvents, getEventsWithSubEvents} from '../../utils/events';
-import {Tooltip} from '@material-ui/core';
-//Replaced Material-ui Button for a Bootstrap implementation. - Turku
-import {Button, Input} from 'reactstrap';
+import {Button, Input, UncontrolledTooltip} from 'reactstrap';
 import {confirmAction} from '../../actions/app';
 import {getButtonLabel} from '../../utils/helpers';
 import {Link} from 'react-router-dom';
@@ -73,13 +71,15 @@ class EventActionButton extends React.Component {
     }
 
     /**
-     * Returns a Button element and depending on showTermsCheckbox an input element with a label
+     * Returns a Button element with additional input & label element if showTermsCheckbox is true.
+     * If explanationId parameter is given then that string is used to fetch correct error message for the tooltip.
      * @param {boolean} showTermsCheckbox
      * @param {string} buttonLabel
      * @param {boolean} disabled
+     * @param {string} [explanationId=''] - errorMessage
      * @returns {*}
      */
-    getButton(showTermsCheckbox, buttonLabel, disabled) {
+    getButton(showTermsCheckbox, buttonLabel, disabled, explanationId = '') {
         const {action, confirmAction, customAction} = this.props;
         const color = 'secondary';
         /*
@@ -107,6 +107,7 @@ class EventActionButton extends React.Component {
                 </div>
                 }
                 <Button
+                    id={action}
                     disabled={disabled}
                     color={color}
                     className={`editor-${action}-button`}
@@ -114,27 +115,13 @@ class EventActionButton extends React.Component {
                 >
                     <FormattedMessage id={buttonLabel}>{txt => txt}</FormattedMessage>
                 </Button>
-            </Fragment>
-        )
-    }
+                {(disabled && explanationId) &&
+                    <UncontrolledTooltip placement="bottom" target={action} innerClassName='tooltip-disabled' hideArrow>
+                        <FormattedMessage id={explanationId}>{txt => txt}</FormattedMessage>
+                    </UncontrolledTooltip>
+                }
 
-    /**
-     * Return Button that has a tooltip
-     * @see getButton
-     * @param {string} explanationId
-     * @param {boolean} showTermsCheckbox
-     * @param {string} buttonLabel
-     * @param {boolean} disabled
-     * @returns {*}
-     */
-    getToolTip(explanationId,showTermsCheckbox, buttonLabel, disabled) {
-        const {intl} = this.props;
-        return (
-            <Tooltip title={intl.formatMessage({id: explanationId})}>
-                <span>
-                    {this.getButton(showTermsCheckbox, buttonLabel, disabled)}
-                </span>
-            </Tooltip>
+            </Fragment>
         )
     }
 
@@ -182,9 +169,8 @@ class EventActionButton extends React.Component {
 
         return (
             <Fragment>
-                {disabled && explanationId
-                    ? this.getToolTip(explanationId, showTermsCheckbox,buttonLabel,disabled)
-                    : this.getButton(showTermsCheckbox, buttonLabel,disabled)
+                {
+                    this.getButton(showTermsCheckbox, buttonLabel,disabled, explanationId)
                 }
             </Fragment>
         )

--- a/src/components/EventActionButton/EventActionButton.js
+++ b/src/components/EventActionButton/EventActionButton.js
@@ -11,6 +11,7 @@ import {Button, Input, UncontrolledTooltip} from 'reactstrap';
 import {confirmAction} from '../../actions/app';
 import {getButtonLabel} from '../../utils/helpers';
 import {Link} from 'react-router-dom';
+import classNames from 'classnames';
 
 const {PUBLICATION_STATUS, EVENT_STATUS, USER_TYPE} = constants;
 
@@ -80,7 +81,7 @@ class EventActionButton extends React.Component {
      * @returns {*}
      */
     getButton(showTermsCheckbox, buttonLabel, disabled, explanationId = '') {
-        const {action, confirmAction, customAction} = this.props;
+        const {action, confirmAction, customAction, intl} = this.props;
         const color = 'secondary';
         /*
         color = this.getButtonColor(action), to get color based on action.
@@ -107,11 +108,13 @@ class EventActionButton extends React.Component {
                 </div>
                 }
                 <Button
+                    aria-disabled={disabled}
+                    aria-label={(disabled && explanationId) ? intl.formatMessage({id: explanationId}) : null}
                     id={action}
-                    disabled={disabled}
                     color={color}
-                    className={`editor-${action}-button`}
-                    onClick={() => confirmAction ? this.confirmEventAction : customAction()}
+                    className={classNames(`editor-${action}-button`,{'disabled': disabled})}
+                    onClick={() => disabled ? null : confirmAction ? this.confirmEventAction : customAction()}
+                    style={disabled ? {cursor: 'not-allowed'} : null}
                 >
                     <FormattedMessage id={buttonLabel}>{txt => txt}</FormattedMessage>
                 </Button>

--- a/src/components/HelFormFields/UmbrellaSelector/UmbrellaCheckbox.js
+++ b/src/components/HelFormFields/UmbrellaSelector/UmbrellaCheckbox.js
@@ -1,45 +1,35 @@
 import './UmbrellaCheckbox.scss'
 import PropTypes from 'prop-types'
 import React,{Fragment}  from 'react'
-import {Tooltip} from '@material-ui/core'
 //Replaced Material-ui CheckBox for a reactstrap implementation. - Turku
-import {Label, Input} from 'reactstrap';
+import {Label, Input, UncontrolledTooltip} from 'reactstrap';
 
 
 const UmbrellaCheckbox = props => {
-    const {intl, name, checked, disabled, handleCheck, id} = props
+    const {intl, name, checked, disabled, handleCheck} = props
     const tooltipTitle = intl.formatMessage({id: `event-${name.replace('_', '-')}-tooltip`})
-
-
-    
-    const getCheckbox = () => (
-        <div className='UmbrellaCheckbox'>  
-            <label htmlFor={id} className='UmbrellaCheckbox'>
-                <input
-                    className='UmbrellaCheckbox'
-                    id={id}
-                    type='checkbox'
-                    name={name}
-                    onChange={handleCheck}
-                    checked={checked}
-                    disabled={disabled} 
-                />{props.children}
-            </label>       
-        </div>
-    )
 
     return (
         <Fragment>
-            {
-                disabled
-                    ? <Tooltip title={tooltipTitle}>
-                        <span>{getCheckbox()}</span>
-                    </Tooltip>
-                    : getCheckbox()
+            <div className='UmbrellaCheckbox'>
+                <label id={`${name}_label`} className='UmbrellaCheckbox'>
+                    <input
+                        className='UmbrellaCheckbox'
+                        type='checkbox'
+                        name={name}
+                        onChange={handleCheck}
+                        checked={checked}
+                        disabled={disabled}
+                    />{props.children}
+                </label>
+            </div>
+            {disabled &&
+                <UncontrolledTooltip placement="bottom" target={`${name}_label`} innerClassName='tooltip-disabled' hideArrow>
+                    {tooltipTitle}
+                </UncontrolledTooltip>
             }
         </Fragment>
     )
-        
 }
 
 
@@ -50,7 +40,6 @@ UmbrellaCheckbox.propTypes = {
     checked: PropTypes.bool,
     disabled: PropTypes.bool,
     handleCheck: PropTypes.func,
-    id: PropTypes.string,
 }
 
 export default UmbrellaCheckbox

--- a/src/i18n/sv.json
+++ b/src/i18n/sv.json
@@ -226,7 +226,7 @@
 
     "event-action-save-draft-new": "Skicka in för granskning",
     "event-action-save-draft-existing": "Uppdatera förslag",
-    "event-action-save-new": "Julkaise tapahtuma",
+    "event-action-save-new": "Publicera händelse",
     "event-action-save-new-active": "Julkaistaan tapahtumaa",
     "event-action-save-existing": "Tallenna muutokset julkaistuun tapahtumaan",
     "event-action-save-existing-active": "Tallennetaan muutoksia",


### PR DESCRIPTION
Replaced material-ui Tooltip with reactstrap Tooltip, minor refactoring to EventActionButton & UmbrellaCheckbox, added tooltip styling to make the new tooltip look like the old one.