### PR TITLE
Changed notifications to update language when user changes language

### DIFF
--- a/src/views/Notification/index.js
+++ b/src/views/Notification/index.js
@@ -72,6 +72,8 @@ Notifications.propTypes = {
 const mapDisPatchToProps = (dispatch) => ({
     clearFlashMsg: () => dispatch(clearFlashMsgAction()),
 }) 
-const mapStateToProps = () => ({})
-// TODO: if leave null, react-intl not refresh. Replace this with better React context
+const mapStateToProps = (state) => ({
+    locale: state.userLocale.locale,
+})
+
 export default connect(mapStateToProps, mapDisPatchToProps)(Notifications)

--- a/src/views/Notification/index.js
+++ b/src/views/Notification/index.js
@@ -67,6 +67,7 @@ class Notifications extends React.Component {
 Notifications.propTypes = {
     flashMsg: PropTypes.object,
     clearFlashMsg: PropTypes.func,
+    locale: PropTypes.string,
 }
 
 const mapDisPatchToProps = (dispatch) => ({
@@ -76,4 +77,5 @@ const mapStateToProps = (state) => ({
     locale: state.userLocale.locale,
 })
 
+export {Notifications as UnconnectedNotifications}
 export default connect(mapStateToProps, mapDisPatchToProps)(Notifications)

--- a/src/views/Notification/tests/Notifications.test.js
+++ b/src/views/Notification/tests/Notifications.test.js
@@ -1,0 +1,73 @@
+import React from 'react'
+import {shallow} from 'enzyme';
+import {IntlProvider} from 'react-intl';
+import fiMessages from 'src/i18n/fi.json';
+import mapValues from 'lodash/mapValues';
+import {UnconnectedNotifications} from '../index'
+
+const testMessages = mapValues(fiMessages, (value, key) => value);
+const intlProvider = new IntlProvider({locale: 'fi', messages: testMessages}, {});
+const {intl} = intlProvider.getChildContext();
+
+describe('Notifications', () => {
+    const defaultProps = {}
+
+    const flashMsg = {
+        action: undefined,
+        data: {sticky: true},
+        msg: 'editor-authorization-required',
+        sticky: true,
+        style: 'error',
+    }
+
+    function getWrapper(props) {
+        return shallow(<UnconnectedNotifications {...defaultProps} {...props}/>, {context: {intl}});
+    }
+
+    describe('when flash message is defined', () => {
+        test('renders div', () => {
+            const isSticky =  flashMsg && flashMsg.sticky
+            const duration = isSticky ? null : 7000
+            const div = getWrapper({flashMsg}).find('div')
+            expect(div).toHaveLength(1)
+            expect(div.prop('open')).toBe(!!flashMsg)
+            expect(div.prop('autohideduration')).toBe(duration)
+            expect(div.prop('onClose')).toBeDefined()
+        })
+
+        test('renders paragraph', () => {
+            const paragraph = getWrapper({flashMsg}).find('p')
+            expect(paragraph).toHaveLength(1)
+            expect(paragraph.prop('className')).toBe('text-center')
+            expect(paragraph.prop('role')).toBe('alert')
+            expect(paragraph.prop('tabIndex')).toBe('0')
+            expect(paragraph.text()).toBe('<FormattedMessage />')
+        })
+    })
+
+    describe('when flash message is not defined', () => {
+        test('doesnt render div', () => {
+            const div = getWrapper().find('div')
+            expect(div).toHaveLength(0)
+        })
+
+        test('doesnt render paragraph', () => {
+            const paragraph = getWrapper().find('p')
+            expect(paragraph).toHaveLength(0)
+        })
+    })
+
+    describe('shouldComponentUpdate', () => {
+        test('returns true when props have changed', () => {
+            const wrapper = getWrapper()
+            const instance = wrapper.instance()
+            expect(instance.shouldComponentUpdate({flashMsg})).toBe(true)
+        })
+
+        test('returns false when props have not changed', () => {
+            const wrapper = getWrapper({flashMsg})
+            const instance = wrapper.instance()
+            expect(instance.shouldComponentUpdate({flashMsg})).toBe(false)
+        })
+    })
+})


### PR DESCRIPTION
Changing language in editor now updates the "you must be logged in to edit events" message language.