### PR TITLE
Feature/multilanguage video fields

### DIFF
--- a/src/components/EventDetails/index.js
+++ b/src/components/EventDetails/index.js
@@ -282,13 +282,25 @@ const VideoValue = ({values}) => {
                     className={'video-item--container'}
                 >
                     {Object.entries(item)
-                        .map(([key, value]) => (
-                            <TextValue
-                                key={`video-value-${key}`}
-                                labelKey={`event-video-${key}`}
-                                value={value}
-                            />
-                        ))
+                        .map(([key, value]) => {
+                            if (key === 'url') {
+                                return (
+                                    <TextValue
+                                        key={`video-value-${key}`}
+                                        labelKey={`event-video-${key}`}
+                                        value={value}
+                                    />
+                                )
+                            } else {
+                                return (
+                                    <MultiLanguageValue
+                                        key={`video-value-${key}`}
+                                        labelKey={`event-video-${key}`}
+                                        value={value}
+                                    />
+                                )
+                            }
+                        })
                     }
                 </div>
             ))}

--- a/src/components/FormFields/index.js
+++ b/src/components/FormFields/index.js
@@ -535,6 +535,7 @@ class FormFields extends React.Component {
                     validationErrors={validationErrors}
                     setDirtyState={this.props.setDirtyState}
                     intl={this.context.intl}
+                    action={this.props.action}
                 />
 
                 <FormHeader>

--- a/src/components/FormFields/index.js
+++ b/src/components/FormFields/index.js
@@ -534,6 +534,7 @@ class FormFields extends React.Component {
                     defaultValues={values['videos']}
                     validationErrors={validationErrors}
                     setDirtyState={this.props.setDirtyState}
+                    intl={this.context.intl}
                 />
 
                 <FormHeader>

--- a/src/components/HelFormFields/HelVideoFields/HelVideoFields.js
+++ b/src/components/HelFormFields/HelVideoFields/HelVideoFields.js
@@ -1,173 +1,301 @@
-import './HelVideoFields.scss'
+import './HelVideoFields.scss';
 
-import React, {useState, useEffect} from 'react'
+import React from 'react';
 import PropTypes from 'prop-types';
-import {FormattedMessage} from 'react-intl'
-import {setData as setDataAction} from 'src/actions/editor'
-import {HelTextField} from '../index'
-import {SideField} from '../../FormFields'
-import {connect} from 'react-redux'
-// import {IconButton, withStyles} from '@material-ui/core'
-import constants from '../../../constants'
-import {get, set, isEqual, isEmpty} from 'lodash'
-// import {Add, Delete} from '@material-ui/icons'
-// import {Button} from 'reactstrap';
+import {FormattedMessage} from 'react-intl';
+import {setData as setDataAction} from 'src/actions/editor';
+import {HelTextField, MultiLanguageField} from '../index';
+import {SideField} from '../../FormFields';
+import {connect} from 'react-redux';
+import classNames from 'classnames';
+import {isEmpty, get} from 'lodash';
+import {Button} from 'reactstrap';
+import update from 'immutability-helper';
 
-const {VALIDATION_RULES, CHARACTER_LIMIT} = constants
-
-// const AddButton = withStyles(theme => ({
-//     root: {
-//         marginTop: theme.spacing(2),
-//     },
-// }))(Button)
-
-// const DeleteButton = withStyles(theme => ({
-//     root: {
-//         alignSelf: 'center',
-//         position: 'absolute',
-//         left: 0,
-//         transform: `translateX(calc(-1.2em - ${theme.spacing(3)}px))`,
-//         '& svg': {
-//             height: '1.2em',
-//             width: '1.2em',
-//         },
-//     },
-// }))(IconButton)
+import constants from 'src/constants';
+const  {VALIDATION_RULES} = constants;
 
 /**
- * Handle blur
- * @param state
- * @param setData
- * @param setDirtyState
+ * empty video object
+ * @type {{alt_text: {}, name: {}, url: string}}
  */
-const handleBlur = (state, setData, setDirtyState) => {
-    setData({videos: state})
-    setDirtyState()
-}
+const EMPTY_VIDEO = {
+    name: {},
+    alt_text: {},
+    url: '',
+};
 
-/**
- * Handle add
- * @param setState
- */
-const handleAdd = (setState) =>
-    setState(state => ([
-        ...state,
-        {
-            name: '',
-            url: '',
-            alt_text: '',
-        },
-    ]))
 
-/**
- * Handle delete
- * @param index
- * @param state
- * @param setData
- */
-const handleDelete = (index, state, setData) =>
-    setData({videos: state.filter((item, itemIndex) => itemIndex !== index)})
+class HelVideoFields extends React.Component {
+    constructor(props) {
+        super(props);
 
-/**
- * Returns the validation props for the text field based on given key
- * @param key
- */
-const getValidationProps = (key) => {
-    if (key === 'url') {
-        return {
-            validations: [VALIDATION_RULES.IS_URL],
+        this.state = {
+            videos: [],
+        }
+        this.handleAddVideo = this.handleAddVideo.bind(this);
+        this.handleDeleteVideo = this.handleDeleteVideo.bind(this);
+    }
+
+
+    componentDidMount() {
+        const defaultValues = this.props.defaultValues;
+        if (defaultValues && defaultValues.length > 0) {
+            this.setState({videos: this.props.defaultValues})
+        } else {
+            this.setState({videos: [Object.assign({}, EMPTY_VIDEO)]})
         }
     }
-    if (key === 'name') {
-        return {
-            maxLength: CHARACTER_LIMIT.SHORT_STRING,
-            validations: [VALIDATION_RULES.SHORT_STRING],
+
+    /**
+     * If prevProps languages !== this.props.languages
+     * ie. ['fi','sv'] -> ['fi'] then the 'sv' keys with their values are removed
+     * and the result is dispatched to redux store.
+     * @param prevProps
+     * @param prevState
+     * @param snapshot
+     * @example
+     * {
+     *     name: {
+     *         fi: 'finnish',
+     *         sv: 'swedish',
+     *     },
+     *
+     * }
+     * becomes
+     * {
+     *     name: {
+     *         fi: 'finnish',
+     *     },
+     * }
+     */
+    componentDidUpdate(prevProps, prevState, snapshot) {
+        if (prevProps.languages !== this.props.languages) {
+            const usedLanguages = this.props.languages;
+            let videos = this.state.videos;
+
+            for (let video of videos) {
+                for (let key in video) {
+                    if (typeof video[key] === 'object') {
+                        Object.keys(video[key]).forEach((k) => {
+                            if (!usedLanguages.includes(k)) {
+                                video[key] = update(video[key], {
+                                    $unset: [k],
+                                })
+                            }
+                        })
+                    }
+                }
+            }
+            this.props.setData({videos: videos});
         }
     }
-    if (key === 'alt_text') {
-        return {
-            maxLength: CHARACTER_LIMIT.MEDIUM_STRING,
-            validations: [VALIDATION_RULES.MEDIUM_STRING],
-        }
+
+    /**
+     * Sends dispatch containing current videos to redux store
+     * @param event
+     * @param value
+     * @param video
+     */
+    handleBlur(event, value, video) {
+        this.props.setData({videos: video});
     }
-}
 
-const HelVideoFields = ({
-    defaultValues,
-    setData,
-    validationErrors,
-    setDirtyState = () => {},
-}) => {
-    const [state, setState] = useState([{
-        name: '',
-        url: '',
-        alt_text: '',
-    }])
-    useEffect(() => {
-        if (defaultValues && defaultValues.length > 0 && !isEqual(defaultValues, state)) {
-            setState(defaultValues)
+    /**
+     *
+     * Sets value object to the correct video , if the object value is empty then { } is set.
+     * @param {Object} event
+     * @param {Object} value
+     * @param {string} name - key where value is to be set
+     * @param {number} index - index of video in state.videos array
+     * @example
+     *  if name: {fi: ''}
+     *  then name: { }
+     */
+    handleChange(event, value, name, index) {
+        const usedLanguages = this.props.languages;
+        this.setState(state => {
+            let videos = [...state.videos];
+
+            if (name !== 'url' && typeof value === 'object') {
+                let hasData;
+                Object.entries(value).forEach((entry, index) => {
+                    if (usedLanguages.length > 1) {hasData = entry.some(x => x.length > 0)}
+                    else {hasData = entry.every(x => x.length > 0)}
+                })
+                if (!hasData) {value = {}}
+            }
+
+            let target = videos[index];
+            videos[index] = update(target, {
+                [name]: {
+                    $set: value,
+                },
+            })
+            return {videos};
+        });
+    }
+
+    /**
+     * Adds one video to state.videos array
+     * @example
+     * state.videos = [{video}]
+     * handleAddVideo()
+     * state.videos = [{video}{video}]
+     */
+    handleAddVideo() {
+        let updatedStateVideos = this.state.videos;
+        updatedStateVideos = update(updatedStateVideos, {$push:[Object.assign({}, EMPTY_VIDEO)]});
+        this.setState({videos: updatedStateVideos})
+    }
+
+    /**
+     * Removes video at index from state.videos
+     * @example
+     * state.videos = [{one}{two}{three}]
+     * handleDeleteVideo(1)
+     * state.videos = [{one}{three}]
+     */
+    handleDeleteVideo(index) {
+        const currentStateVideos = this.state.videos;
+        const filteredCurrentStateVideos = currentStateVideos.filter((video, itemIndex) => itemIndex !== index);
+        this.setState({videos: filteredCurrentStateVideos});
+        this.props.setData({videos: filteredCurrentStateVideos});
+    }
+
+
+    /**
+     * Checks if video contains any values are not length > 0
+     * @example
+     * {
+     *     name: {
+     *         fi: '',
+     *     }
+     *     alt_text: {
+     *         fi: '',
+     *     },
+     *     url: '',
+     * } // this video would return False
+     * {
+     *     name: {
+     *         fi:'',
+     *     },
+     *     alt_text: {
+     *         fi:'test',
+     *     },
+     *     url: '',
+     * } // this video would return True
+     * @param {Object} video
+     * @returns {boolean}
+     */
+    checkIfRequired(video) {
+        const entries = Object.values(video);
+        let result;
+
+        for (const entry of entries) {
+            if (result) {break}
+            if (typeof entry === 'object') {
+                for (const key in entry) {
+                    result = !isEmpty(entry[key]);
+                    if (result) {break}
+                }
+            }
+            if (typeof entry === 'string') {result = entry.length > 0;}
         }
-    }, [defaultValues])
+        return result;
+    }
 
-    return (
-        <div className="row event-videos">
-            <div className="col-xs-12 col-sm-6">
-                {state.map((item, index) => (
-                    <div
-                        key={`video-field-${index}`}
-                        className={`event-videos--item-container ${state.length > 1 ? 'indented' : ''}`}
-                    >
-                        <div className={'event-videos--item-inputs'}>
-                            {Object.entries(item)
-                                .map(([key, value]) => {
-                                    const required = !Object.values(item).every(isEmpty)
+    render() {
 
-                                    return (
-                                        <HelTextField
-                                            id={`event-video-${key}`}
-                                            key={`${key}-video-field`}
-                                            required={required}
-                                            defaultValue={value}
-                                            label={<FormattedMessage id={`event-video-${key}`}/>}
-                                            validationErrors={get(validationErrors, ['videos', index, key], {})}
-                                            onChange={e => setState(state => set(state, [index, key], e.target.value))}
-                                            onBlur={() => handleBlur(state, setData, setDirtyState)}
-                                            {...getValidationProps(key)}
-                                        />
-                                    )
-                                })}
+        // TODO: Uncomment the Button components to enable adding multiple video fields.
+        // Everything should work with multiple videos but it should be tested/checked before using.
+
+        const stateVideos = this.state.videos;
+        const required = stateVideos.map(video => this.checkIfRequired(video));
+        return (
+            <React.Fragment>
+                <div className="row event-videos">
+
+                    <div className="col-xs-12 col-sm-6">
+                        {stateVideos.map((video, index) => (
+                            <div key={`video-field-${index}`} className={classNames('event-videos--item-container', {'indented': this.state.videos.length > 1})}>
+                                <div className='event-videos--item-inputs'>
+                                    { /*this.state.videos.length > 1 &&
+                                    <Button
+                                        size='sm'
+                                        onClick={() => this.handleDeleteVideo(index)}
+                                        style={{left: '480px', position: 'absolute'}}
+                                    >
+                                        {this.props.intl.formatMessage({id: 'delete'})}
+                                    </Button>
+
+                                    */}
+                                    <HelTextField
+                                        id='event-video-url'
+                                        key='url-video-field'
+                                        required={required[index]}
+                                        defaultValue={video.url}
+                                        label={<FormattedMessage id='event-video-url' />}
+                                        validations={[VALIDATION_RULES.IS_URL]}
+                                        validationErrors={get(this.props.validationErrors,['videos', index, 'url'], {})}
+                                        onChange={(e, v) => this.handleChange(e, v, 'url', index)}
+                                        onBlur={(e, v) => this.handleBlur(e, v, this.state.videos)}
+                                    />
+
+                                    <MultiLanguageField
+                                        id='event-video-name'
+                                        defaultValue={video.name}
+                                        required={required[index]}
+                                        multiLine={false}
+                                        validations={[VALIDATION_RULES.SHORT_STRING]}
+                                        validationErrors={get(this.props.validationErrors,['videos', index, 'name'], {})}
+                                        label='event-video-name'
+                                        languages={this.props.languages}
+                                        onChange={(e, v) => this.handleChange(e, v, 'name', index)}
+                                        onBlur={(e, v) => this.handleBlur(e, v, this.state.videos)}
+                                    />
+                                    <MultiLanguageField
+                                        id='event-video-alt_text'
+                                        defaultValue={video.alt_text}
+                                        required={required[index]}
+                                        multiLine={false}
+                                        validations={[VALIDATION_RULES.MEDIUM_STRING]}
+                                        validationErrors={get(this.props.validationErrors,['videos', index, 'alt_text'], {})}
+                                        label='event-video-alt_text'
+                                        languages={this.props.languages}
+                                        onChange={(e, v) => this.handleChange(e, v, 'alt_text', index)}
+                                        onBlur={(e, v) => this.handleBlur(e, v, this.state.videos)}
+                                    />
+                                </div>
+                            </div>
+                        ))}
+                        {/*
+                        <div>
+                            <Button
+                                size='lg'
+                                block
+                                onClick={this.handleAddVideo}
+                            >
+                                {this.context.intl.formatMessage({id: 'event-video-add'})}
+                            </Button>
                         </div>
-                        {/* {state.length > 1 &&
-                        <DeleteButton
-                            color="secondary"
-                            onClick={() => handleDelete(index, state, setData)}
-                        >
-                            <Delete/>
-                        </DeleteButton>
-                        } */}
+                        */}
                     </div>
-                ))}
-                {/*
-                TODO: Uncomment the add button to support adding multiple video fields
-                <AddButton
-                    fullWidth
-                    variant="contained"
-                    color="primary"
-                    startIcon={<Add/>}
-                    onClick={() => handleAdd(setState)}
-                >
-                    <FormattedMessage id="event-video-add"/>
-                </AddButton>
-                */}
-            </div>
-            <SideField>
-                <div className="tip">
-                    <p><FormattedMessage id="editor-tip-video"/></p>
-                    <p><FormattedMessage id="editor-tip-video-fields"/></p>
+                    <SideField>
+                        <div className="tip">
+                            <p><FormattedMessage id="editor-tip-video"/></p>
+                            <p><FormattedMessage id="editor-tip-video-fields"/></p>
+                        </div>
+
+                    </SideField>
                 </div>
-            </SideField>
-        </div>
-    )
+            </React.Fragment>
+        )
+    }
+}
+
+HelVideoFields.contextTypes = {
+    intl: PropTypes.object,
 }
 
 HelVideoFields.propTypes = {
@@ -175,12 +303,19 @@ HelVideoFields.propTypes = {
     defaultValues: PropTypes.array,
     validationErrors: PropTypes.object,
     setDirtyState: PropTypes.func,
+    languages: PropTypes.array,
+    intl: PropTypes.object,
+    editorValues: PropTypes.object,
 }
 
-const mapStateToProps = () => ({})
+const mapStateToProps = (state) => ({
+    languages: state.editor.contentLanguages,
+    editorValues: state.editor.values,
+})
 
 const mapDispatchToProps = (dispatch) => ({
     setData: (value) => dispatch(setDataAction(value)),
-})
+});
 
+export {HelVideoFields as UnconnectedHelVideoFields}
 export default connect(mapStateToProps, mapDispatchToProps)(HelVideoFields)

--- a/src/components/HelFormFields/HelVideoFields/HelVideoFields.js
+++ b/src/components/HelFormFields/HelVideoFields/HelVideoFields.js
@@ -89,6 +89,9 @@ class HelVideoFields extends React.Component {
             }
             this.props.setData({videos: videos});
         }
+        if (prevProps.action === 'update' && this.props.action === 'create') {
+            this.setState({videos: [Object.assign({}, EMPTY_VIDEO)]})
+        }
     }
 
     /**
@@ -299,6 +302,7 @@ HelVideoFields.contextTypes = {
 }
 
 HelVideoFields.propTypes = {
+    action: PropTypes.string,
     setData: PropTypes.func,
     defaultValues: PropTypes.array,
     validationErrors: PropTypes.object,

--- a/src/components/HelFormFields/tests/HelVideoFields.test.js
+++ b/src/components/HelFormFields/tests/HelVideoFields.test.js
@@ -1,0 +1,275 @@
+import React from 'react';
+import {mount} from 'enzyme';
+import {mockEditorNewEvent} from '__mocks__/mockData';
+import {IntlProvider} from 'react-intl';
+import mapValues from 'lodash/mapValues';
+import fiMessages from 'src/i18n/fi.json';
+
+jest.mock('@city-i18n/localization.json', () => ({
+    mapPosition: [60.451744, 22.266601],
+}),{virtual: true});
+
+jest.mock('@city-assets/urls.json', () => ({
+    rasterMapTiles: 'this is a url to the maptiles',
+}),{virtual: true});
+
+import {UnconnectedHelVideoFields} from '../HelVideoFields/HelVideoFields';
+import {SideField} from '../../FormFields';
+import {HelTextField} from '../index';
+const testMessages = mapValues(fiMessages, (value, key) => value);
+const intlProvider = new IntlProvider({locale: 'fi', messages: testMessages});
+const {intl} = intlProvider.getChildContext();
+const mockEditor = mockEditorNewEvent;
+
+
+
+describe('HelVideoFields', () => {
+    const defaultProps = {
+        setData: jest.fn(),
+        clearVideos: jest.fn(),
+        validationErrors: {},
+        setDirtyState: jest.fn(),
+        languages: mockEditor.contentLanguages,
+        intl: {intl},
+        editorValues: {},
+        defaultValues: [],
+    };
+    const MOCK_VIDEO = {
+        url: 'http://www.turku.fi/',
+        name: {fi: 'This is the finnish name of the first video'},
+        alt_text: {fi: 'This is the finnish alt text for the first video.'},
+    };
+    const MOCK_VIDEO_2 = {
+        url: 'http://www.turku.fi/sv',
+        name: {fi: 'This is the finnish name of the second video'},
+        alt_text: {fi: 'This is the finnish alt text for the second video.'},
+    };
+
+    const EMPTY_VIDEO = {
+        url: '',
+        name: {},
+        alt_text: {},
+    };
+
+    function getWrapper(props) {
+        return mount(<UnconnectedHelVideoFields {...defaultProps} {...props} />, {context: {intl}});
+    }
+
+
+    describe('methods', () => {
+
+        describe('componentDidMount', () => {
+            let componentDidMount;
+            let wrapper;
+
+            beforeEach(() => {
+                componentDidMount = jest.spyOn(UnconnectedHelVideoFields.prototype, 'componentDidMount');
+            });
+
+            afterEach(() => {
+                wrapper.unmount();
+            });
+
+            test('has been called when mounted', () => {
+                wrapper = getWrapper();
+
+                expect(componentDidMount).toHaveBeenCalled();
+            });
+
+            test('sets defaultValues to state', () => {
+                wrapper = getWrapper({defaultValues:[MOCK_VIDEO]});
+
+                expect(componentDidMount).toHaveBeenCalled();
+                expect(wrapper.state()).toEqual({
+                    videos:[MOCK_VIDEO],
+                });
+            });
+
+            test('sets empty video object to state if no defaultValues', () => {
+                wrapper = getWrapper();
+
+                expect(wrapper.state()).toEqual({
+                    videos:[EMPTY_VIDEO],
+                });
+            });
+        });
+
+        describe('componentDidUpdate', () => {
+            test('setData is called with correct prop if prevProps.languages !== this.props.languages', () => {
+                const multiLangVideo = _.cloneDeep(MOCK_VIDEO);
+                multiLangVideo.name.sv = 'This is the swedish name of the video';
+                multiLangVideo.alt_text.sv = 'This is the swedish alt text of the video';
+                let wrapper = getWrapper({defaultValues:[multiLangVideo]});
+                let instance = wrapper.instance();
+                const spy = jest.spyOn(instance.props,'setData');
+
+                wrapper.setProps({languages:['fi']});
+                expect(spy).toHaveBeenCalledWith({videos: [MOCK_VIDEO]});
+
+            })
+        })
+
+        describe('handleBlur', () => {
+            let wrapper;
+
+
+            afterEach(() => {
+                wrapper.unmount();
+            });
+
+            test('calls setData ', () => {
+                wrapper = getWrapper();
+                const instance = wrapper.instance();
+                const spy = jest.spyOn(instance.props, 'setData');
+                const correctVideo = _.cloneDeep(MOCK_VIDEO);
+
+                instance.handleBlur({},{},[correctVideo]);
+                expect(spy).toHaveBeenCalled();
+            });
+        });
+
+        describe('handleChange', () => {
+            test('changes a video', () => {
+                const wrapper = getWrapper({defaultValues: [MOCK_VIDEO]});
+                const instance = wrapper.instance();
+
+                expect(wrapper.state()).toEqual({videos: [MOCK_VIDEO]});
+                instance.handleChange({}, {fi: 'New name for the video'},'name', 0);
+
+                const expectedValue = Object.assign({}, MOCK_VIDEO);
+                expectedValue.name.fi = 'New name for the video';
+                expect(wrapper.state()).toEqual({videos: [expectedValue]})
+            });
+
+            test('changes correct video according to index', () => {
+                const expectedValue = Object.assign({}, MOCK_VIDEO);
+                expectedValue.name.fi = 'Finnish name';
+                const wrapper = getWrapper({defaultValues: [MOCK_VIDEO, MOCK_VIDEO_2]});
+                const instance = wrapper.instance();
+
+                expect(wrapper.state()).toEqual({videos: [MOCK_VIDEO, MOCK_VIDEO_2]});
+
+                instance.handleChange({},{fi: 'Finnish name'},'name',0);
+                expect(wrapper.state()).toEqual({videos: [expectedValue, MOCK_VIDEO_2 ]});
+
+            });
+        });
+
+        describe('handleAddVideo', () => {
+            test('adds a video to state' ,() => {
+                const wrapper = getWrapper();
+
+                expect(wrapper.state()['videos'].length).toBe(1);
+
+                wrapper.instance().handleAddVideo();
+                expect(wrapper.state()['videos'].length).toBe(2);
+
+                wrapper.instance().handleAddVideo();
+                expect(wrapper.state()['videos'].length).toBe(3);
+            });
+        });
+
+        describe('handleDeleteVideo', () => {
+            test('removes video at index', () => {
+                const wrapper = getWrapper({defaultValues: [MOCK_VIDEO]});
+
+                wrapper.instance().handleAddVideo();
+                expect(wrapper.state()['videos'].length).toBe(2);
+
+                wrapper.instance().handleDeleteVideo(0);
+                expect(wrapper.state()['videos'].length).toBe(1);
+                expect(wrapper.state()['videos'][0]).not.toBe(MOCK_VIDEO);
+            });
+        });
+
+        describe('checkIfRequired', () => {
+            let wrapper;
+            let instance;
+
+            beforeEach(() => {
+                wrapper = getWrapper();
+                instance = wrapper.instance();
+            })
+
+            afterEach(() => {
+                wrapper.unmount();
+            })
+
+            test('returns true if object contains a value', () => {
+                const partialVideo = _.cloneDeep(EMPTY_VIDEO);
+                partialVideo.name.fi = 'This is a new name for the vi'
+                const actual = instance.checkIfRequired(partialVideo);
+
+                expect(actual).toBe(true);
+            });
+
+            test('returns false if object contains no values', () => {
+                const emptyVideo = _.cloneDeep(EMPTY_VIDEO);
+                const actual = instance.checkIfRequired(emptyVideo);
+
+                expect(actual).toBe(false);
+            });
+
+        });
+
+    });
+
+    describe('render', () => {
+
+        describe('HelTextField', () => {
+            test('correct amount of HelTextFields, 1 + 2 * amount of languages', () => {
+                const contentLanguages = ['fi']; // length = 1
+
+                let wrapper = getWrapper({languages: contentLanguages});
+                let textFieldElements = wrapper.find(HelTextField);
+
+                // textFieldElements should be 3
+                expect(textFieldElements).toHaveLength(1 + 2 * contentLanguages.length);
+
+                contentLanguages.push('sv'); // length = 2
+                wrapper = getWrapper({languages: contentLanguages});
+                textFieldElements = wrapper.find(HelTextField);
+
+                // textFieldElements length should be 5
+                expect(textFieldElements).toHaveLength(1 + 2 * contentLanguages.length);
+
+                contentLanguages.push('en'); // length = 3
+                wrapper = getWrapper({languages: contentLanguages});
+                textFieldElements = wrapper.find(HelTextField);
+
+                // textFieldElements length should be 7
+                expect(textFieldElements).toHaveLength(1 + 2 * contentLanguages.length);
+            });
+
+            test('required prop changes true/false depending on if a value has been added', () => {
+                const wrapper = getWrapper();
+                function randomKey(foo) {
+                    return foo[Math.floor(Math.random() * foo.length)];
+                }
+
+                let textFieldElements = wrapper.find(HelTextField);
+                expect(textFieldElements.at(randomKey([0, 1, 2])).prop('required')).toBe(false);
+
+                wrapper.instance().handleChange({},{fi:'finnish alt text'},'alt_text', 0);
+                wrapper.update();
+
+                textFieldElements = wrapper.find(HelTextField);
+                expect(textFieldElements.at(randomKey([0, 1, 2])).prop('required')).toBe(true);
+
+                wrapper.instance().handleChange({},{fi:''},'alt_text', 0);
+                wrapper.update();
+
+                textFieldElements = wrapper.find(HelTextField);
+                expect(textFieldElements.at(randomKey([0, 1, 2])).prop('required')).toBe(false);
+            });
+        });
+        describe('SideField', () => {
+            test('is rendered', () => {
+                const wrapper = getWrapper();
+                const sideFieldElement = wrapper.find(SideField);
+                expect(sideFieldElement).toHaveLength(1);
+            });
+        });
+    });
+});
+

--- a/src/components/HelFormFields/tests/HelVideoFields.test.js
+++ b/src/components/HelFormFields/tests/HelVideoFields.test.js
@@ -25,6 +25,7 @@ const mockEditor = mockEditorNewEvent;
 
 describe('HelVideoFields', () => {
     const defaultProps = {
+        action: 'create',
         setData: jest.fn(),
         clearVideos: jest.fn(),
         validationErrors: {},
@@ -105,9 +106,17 @@ describe('HelVideoFields', () => {
 
                 wrapper.setProps({languages:['fi']});
                 expect(spy).toHaveBeenCalledWith({videos: [MOCK_VIDEO]});
+                wrapper.unmount();
+            });
 
-            })
-        })
+            test('if prevProps.action was update && this.props.action is create -> clear state by setting it to an empty video', () =>{
+                const wrapper = getWrapper({defaultValues:[MOCK_VIDEO], action: 'update'});
+                expect(wrapper.state()).toEqual({videos:[MOCK_VIDEO]});
+                wrapper.setProps({action: 'create'});
+                expect(wrapper.state()).toEqual({videos:[EMPTY_VIDEO]});
+            });
+
+        });
 
         describe('handleBlur', () => {
             let wrapper;

--- a/src/validation/validationRules.js
+++ b/src/validation/validationRules.js
@@ -14,7 +14,13 @@ let _isExisty = function _isExisty(value) {
 }
 
 let isEmpty = function isEmpty(value) {
-    return value === '';
+
+    if (value === '') {return true}
+    else if (typeof value == 'object') {
+        const vals = Object.values(value);
+        if (vals.length > 0 && vals[0] === '') {return true}
+        if (vals.length === 0) {return true}
+    }
 }
 
 const _containsAllLanguages = (value, languages) => {


### PR DESCRIPTION
Reworked HelVideoFields so that it supports language-specific input fields for name and alt_text. Added functionality to add/remove additional videos although the buttons for this are commented out. Fixed the isEmpty function in validationRules to work with the new language-specific fields.

Modified EventDetails to display the language-specific name & alt_text for the event.

