### PR TITLE
editorpage component order switch

### DIFF
--- a/src/components/FormFields/index.js
+++ b/src/components/FormFields/index.js
@@ -311,6 +311,14 @@ class FormFields extends React.Component {
                     <FormattedMessage id="event-datetime-fields-header" />
                 </FormHeader>
                 <div className="row date-row">
+                    <SideField>
+                        <div className="tip">
+                            <p><FormattedMessage id="editor-tip-time-start"/></p>
+                            <p><FormattedMessage id="editor-tip-time-end"/></p>
+                            <p><FormattedMessage id="editor-tip-time-multi"/></p>
+                            <p><FormattedMessage id="editor-tip-time-delete"/></p>
+                        </div>
+                    </SideField>
                     <div className="col-sm-6">
                         <div className="row">
                             <div className="col-xs-12 col-sm-12">
@@ -369,20 +377,21 @@ class FormFields extends React.Component {
                             <FormattedMessage id="event-add-recurring" />
                         </Button>
                     </div>
-                    <SideField>
-                        <div className="tip">
-                            <p><FormattedMessage id="editor-tip-time-start"/></p>
-                            <p><FormattedMessage id="editor-tip-time-end"/></p>
-                            <p><FormattedMessage id="editor-tip-time-multi"/></p>
-                            <p><FormattedMessage id="editor-tip-time-delete"/></p>
-                        </div>
-                    </SideField>
+
                 </div>
 
                 <FormHeader>
                     <FormattedMessage id="event-location-fields-header" />
                 </FormHeader>
                 <div className="row location-row">
+                    <SideField>
+                        <div className="tip">
+                            <p><FormattedMessage id="editor-tip-location"/></p>
+                            <p><strong><FormattedMessage id="editor-tip-location-internet"/></strong></p>
+                            <p><FormattedMessage id="editor-tip-location-extra"/></p>
+                            <p><FormattedMessage id="editor-tip-location-not-found"/></p>
+                        </div>
+                    </SideField>
                     <div className="col-sm-6 hel-select">
 
                         <HelSelect
@@ -449,20 +458,19 @@ class FormFields extends React.Component {
                             type='text'
                         />
                     </div>
-                    <SideField>
-                        <div className="tip">
-                            <p><FormattedMessage id="editor-tip-location"/></p>
-                            <p><strong><FormattedMessage id="editor-tip-location-internet"/></strong></p>
-                            <p><FormattedMessage id="editor-tip-location-extra"/></p>
-                            <p><FormattedMessage id="editor-tip-location-not-found"/></p>
-                        </div>
-                    </SideField>
+
                 </div>
 
                 <FormHeader>
                     <FormattedMessage id="event-price-fields-header" />
                 </FormHeader>
-                <div className="row">
+                <div className="row offers-row">
+                    <SideField>
+                        <div className="tip">
+                            <p><FormattedMessage id="editor-tip-price"/></p>
+                            <p><FormattedMessage id="editor-tip-price-multi"/></p>
+                        </div>
+                    </SideField>
                     <div className="col-sm-6">
                         <HelOffersField
                             ref="offers"
@@ -473,18 +481,14 @@ class FormFields extends React.Component {
                             setDirtyState={this.props.setDirtyState}
                         />
                     </div>
-                    <SideField>
-                        <div className="tip">
-                            <p><FormattedMessage id="editor-tip-price"/></p>
-                            <p><FormattedMessage id="editor-tip-price-multi"/></p>
-                        </div>
-                    </SideField>
+
                 </div>
 
                 <FormHeader>
                     <FormattedMessage id="event-social-media-fields-header" />
                 </FormHeader>
-                <div className="row">
+                <div className="row social-media-row">
+                    <SideField><p className="tip"><FormattedMessage id="editor-tip-social-media"/></p></SideField>
                     <div className="col-sm-6">
                         {/* Removed formatted message from label since it was causing accessibility issues */}
                         <HelTextField
@@ -524,7 +528,7 @@ class FormFields extends React.Component {
                             type='text'
                         />
                     </div>
-                    <SideField><p className="tip"><FormattedMessage id="editor-tip-social-media"/></p></SideField>
+
                 </div>
 
                 <FormHeader>
@@ -550,6 +554,7 @@ class FormFields extends React.Component {
                     />
                 </div>
                 <div className="row audience-row">
+                    <SideField><p className="tip"><FormattedMessage id="editor-tip-hel-target-group"/></p></SideField>
                     <HelLabeledCheckboxGroup
                         groupLabel={<FormattedMessage id="hel-target-groups"/>}
                         selectedValues={values['audience']}
@@ -560,7 +565,7 @@ class FormFields extends React.Component {
                         options={helTargetOptions}
                         setDirtyState={this.props.setDirtyState}
                     />
-                    <SideField><p className="tip"><FormattedMessage id="editor-tip-hel-target-group"/></p></SideField>
+                    <SideField><p className="tip"><FormattedMessage id="editor-tip-event-languages"/></p></SideField>
                     <HelLabeledCheckboxGroup
                         groupLabel={<FormattedMessage id="hel-event-languages"/>}
                         selectedValues={values['in_language']}
@@ -571,7 +576,7 @@ class FormFields extends React.Component {
                         options={helEventLangOptions}
                         setDirtyState={this.props.setDirtyState}
                     />
-                    <SideField><p className="tip"><FormattedMessage id="editor-tip-event-languages"/></p></SideField>
+
                 </div>
 
                 {appSettings.ui_mode === 'courses' &&

--- a/src/components/FormFields/index.scss
+++ b/src/components/FormFields/index.scss
@@ -40,6 +40,14 @@ textarea {
         top: 65px;
     }
 }
+.date-row,
+.offers-row,
+.social-media-row,
+.keyword-row,
+.audience-row,
+.location-row {
+    flex-direction: row-reverse;
+}
 
 // Styling for new Form Inputs
 .event-input {

--- a/src/components/HelFormFields/HelKeywordSelector/HelKeywordSelector.js
+++ b/src/components/HelFormFields/HelKeywordSelector/HelKeywordSelector.js
@@ -68,6 +68,11 @@ const HelKeywordSelector = ({intl, editor, setDirtyState, setData, currentLocale
 
     return (
         <React.Fragment>
+            <SideField>
+                <p className="tip">
+                    <FormattedMessage id="editor-tip-hel-main-category"/>
+                </p>
+            </SideField>
             <HelLabeledCheckboxGroup
                 groupLabel={<FormattedMessage id="main-categories"/>}
                 selectedValues={keywords}
@@ -81,7 +86,7 @@ const HelKeywordSelector = ({intl, editor, setDirtyState, setData, currentLocale
             />
             <SideField>
                 <p className="tip">
-                    <FormattedMessage id="editor-tip-hel-main-category"/>
+                    <FormattedMessage id="editor-tip-keywords"/>
                 </p>
             </SideField>
             <div className="col-sm-6 hel-select">
@@ -105,11 +110,7 @@ const HelKeywordSelector = ({intl, editor, setDirtyState, setData, currentLocale
                     locale={currentLocale}
                 />
             </div>
-            <SideField>
-                <p className="tip">
-                    <FormattedMessage id="editor-tip-keywords"/>
-                </p>
-            </SideField>
+
         </React.Fragment>
     )
 }

--- a/src/components/HelFormFields/HelVideoFields/HelVideoFields.js
+++ b/src/components/HelFormFields/HelVideoFields/HelVideoFields.js
@@ -218,7 +218,13 @@ class HelVideoFields extends React.Component {
         return (
             <React.Fragment>
                 <div className="row event-videos">
+                    <SideField>
+                        <div className="tip">
+                            <p><FormattedMessage id="editor-tip-video"/></p>
+                            <p><FormattedMessage id="editor-tip-video-fields"/></p>
+                        </div>
 
+                    </SideField>
                     <div className="col-xs-12 col-sm-6">
                         {stateVideos.map((video, index) => (
                             <div key={`video-field-${index}`} className={classNames('event-videos--item-container', {'indented': this.state.videos.length > 1})}>
@@ -284,13 +290,7 @@ class HelVideoFields extends React.Component {
                         </div>
                         */}
                     </div>
-                    <SideField>
-                        <div className="tip">
-                            <p><FormattedMessage id="editor-tip-video"/></p>
-                            <p><FormattedMessage id="editor-tip-video-fields"/></p>
-                        </div>
 
-                    </SideField>
                 </div>
             </React.Fragment>
         )

--- a/src/components/HelFormFields/HelVideoFields/HelVideoFields.scss
+++ b/src/components/HelFormFields/HelVideoFields/HelVideoFields.scss
@@ -1,4 +1,5 @@
 .event-videos {
+    flex-direction: row-reverse;
     &--item-container {
         display: flex;
         position: relative;

--- a/src/views/Editor/index.scss
+++ b/src/views/Editor/index.scss
@@ -56,6 +56,10 @@ $actionBtnHeight: 60px;
     }
     .side-field {
         padding-top: 36px;
+        @media (max-width: 768px) {
+            padding-top: 0;
+            padding-bottom: 36px;
+        }
         p {
             font-size: 18px;
             font-weight: 300;


### PR DESCRIPTION
switched the order of components so that SideField is rendered first, the direction is then flipped visually with flex-direction: row-reverse so that it looks the same as before. Previously screen readers arrived at the SideField texts after the inputs, now because the SideField content is before the inputs in the DOM they are read first.