### PR TITLE
fix for old events videos failing validation before editing

### DIFF
--- a/src/validation/validationRules.js
+++ b/src/validation/validationRules.js
@@ -16,7 +16,8 @@ let _isExisty = function _isExisty(value) {
 let isEmpty = function isEmpty(value) {
 
     if (value === '') {return true}
-    else if (typeof value == 'object') {
+    if (value === null) {return true}
+    if (typeof value == 'object') {
         const vals = Object.values(value);
         if (vals.length > 0 && vals[0] === '') {return true}
         if (vals.length === 0) {return true}


### PR DESCRIPTION
Fix, the db changes that were made for the HelVideoFields component nullified the name and alt_text fields of preexisting events with videos. Because they were null, the validation caused an error when trying to edit the event.