### PR TITLE
Fixed labels for MultiLanguageField

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "axios": "^0.19.0",
     "body-parser": "^1.14.1",
     "bootstrap": "4.4.1",
-    "city_theme": ">=0.6.2 <1.0.0",
+    "city_theme": "0.x.x",
     "classnames": "^2.2.6",
     "codecov": "^3.0.0",
     "cookie-parser": "^1.4.0",

--- a/src/components/HelFormFields/MultiLanguageField.js
+++ b/src/components/HelFormFields/MultiLanguageField.js
@@ -154,7 +154,7 @@ class MultiLanguageField extends React.Component {
                             multiLine={this.props.multiLine}
                             required={this.props.required}
                             defaultValue={value} ref={lang}
-                            label={this.context.intl.formatMessage({id: `in-${lang}`})}
+                            label={this.context.intl.formatMessage({id: `${this.props.label}`}) + ' ' + this.context.intl.formatMessage({id: `in-${lang}`})}
                             onChange={(e,v) => this.onChange(e,v,lang)}
                             onBlur={(e,v) => this.onBlur(e,v)}
                             disabled={this.props.disabled}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2422,7 +2422,7 @@ cipher-base@^1.0.0, cipher-base@^1.0.1, cipher-base@^1.0.3:
     inherits "^2.0.1"
     safe-buffer "^5.0.1"
 
-"city_theme@>=0.6.2 <1.0.0":
+city_theme@0.x.x:
   version "0.6.2"
   resolved "https://registry.yarnpkg.com/city_theme/-/city_theme-0.6.2.tgz#45cbf429611e97f472b02b0c57938cba5df649de"
   integrity sha512-piFHrnObVjvEUoeCXK/9JL+g9LS3uYmhLf2j5kk7+d+cOG85ba5u/Vqp58pKIWMpFx1Mz/mNxV1K1guFQYwO/Q==


### PR DESCRIPTION
Labels should now read correctly when adding event information in multiple languages.
Changed city_theme package version to '0.x.x', it will update to the latest patch and minor versions of city_theme automatically without requiring manual package version change.