### PR TITLE
Fixed event start time not being shown as a required field

### DIFF
--- a/src/components/CustomFormFields/CustomDatePicker.js
+++ b/src/components/CustomFormFields/CustomDatePicker.js
@@ -175,13 +175,13 @@ class CustomDatePicker extends React.Component {
     }
 
     render(){
-        const {label, name, id, defaultValue, minDate, maxDate, type, disabled} = this.props
+        const {label, name, id, defaultValue, minDate, maxDate, type, disabled, required} = this.props
         const inputValue = this.state.inputValue
         const inputErrorId = 'date-input-error__' + id
         return(
             <div className="custom-date-input">
                 <FormGroup>
-                    <Label for={id}>{this.getCorrectInputLabel(label)}</Label>
+                    <Label for={id}>{this.getCorrectInputLabel(label)}{required ? '*' : ''}</Label>
                     <div className="input-and-button">
                         <Input
                             aria-describedby={this.state.showValidationError ? inputErrorId : undefined}
@@ -193,6 +193,7 @@ class CustomDatePicker extends React.Component {
                             onChange={this.handleInputChange}
                             onBlur={this.handleInputBlur}
                             disabled={disabled}
+                            required={required}
                         />
                         <DatePicker
                             disabled={disabled}
@@ -231,6 +232,7 @@ CustomDatePicker.defaultProps = {
     type: 'date',
     disablePast: false,
     disabled: false,
+    required: false,
 }
 
 CustomDatePicker.propTypes = {
@@ -247,6 +249,7 @@ CustomDatePicker.propTypes = {
     type: PropTypes.oneOf(['date', 'time', 'date-time']),
     disablePast: PropTypes.bool,
     disabled: PropTypes.bool,
+    required: PropTypes.bool,
 };
 
 class DatePickerButton extends React.Component{

--- a/src/components/CustomFormFields/CustomDateTimeField.js
+++ b/src/components/CustomFormFields/CustomDateTimeField.js
@@ -44,6 +44,7 @@ const CustomDateTimeField = ({
     setDirtyState,
     minDate,
     maxDate,
+    required,
 }) => {
     const containerRef = useRef(null)
 
@@ -60,6 +61,7 @@ const CustomDateTimeField = ({
                 onChange={value => onChange(value, name, eventKey, updateSubEvent, setData, setDirtyState)}
                 minDate={minDate}
                 maxDate={maxDate}
+                required={required}
             />
             <ValidationPopover
                 anchor={containerRef.current}
@@ -85,6 +87,7 @@ CustomDateTimeField.propTypes = {
     ]),
     disabled: PropTypes.bool,
     disablePast: PropTypes.bool,
+    required: PropTypes.bool,
     minDate: PropTypes.oneOfType([
         PropTypes.string,
         PropTypes.object,

--- a/src/components/CustomFormFields/tests/CustomDatePicker.test.js
+++ b/src/components/CustomFormFields/tests/CustomDatePicker.test.js
@@ -30,13 +30,28 @@ describe('CustomDatePicker', () => {
         return shallow(<CustomDatePicker {...defaultProps} {...props} />, {context: {intl}});
     }
     describe('renders', () => {
-        test('label with correct props', () => {
-            const wrapper = getWrapper();
-            const instance = wrapper.instance();
-            const label = getWrapper({}).find(Label)
-            expect(label).toHaveLength(1);
-            expect(label.prop('for')).toBe(defaultProps.id)
-            expect(label.prop('children')).toEqual(instance.getCorrectInputLabel(defaultProps.label))
+        describe('label', () => {
+            test('with correct props', () => {
+                const wrapper = getWrapper();
+                const instance = wrapper.instance();
+                const label = wrapper.find(Label)
+                expect(label).toHaveLength(1);
+                expect(label.prop('for')).toBe(defaultProps.id)
+            })
+            test('with correct text when field is required', () => {
+                const required = true
+                const wrapper = getWrapper({required});
+                const instance = wrapper.instance();
+                const label = wrapper.find(Label)
+                expect(label.prop('children')).toEqual([instance.getCorrectInputLabel(defaultProps.label), '*'])
+            })
+            test('with correct text when field is not required', () => {
+                const required = false
+                const wrapper = getWrapper({required});
+                const instance = wrapper.instance();
+                const label = wrapper.find(Label)
+                expect(label.prop('children')).toEqual([instance.getCorrectInputLabel(defaultProps.label), ''])
+            })
         })
 
         describe('Input', () => {
@@ -53,6 +68,7 @@ describe('CustomDatePicker', () => {
                 expect(input.prop('onBlur')).toBe(instance.handleInputBlur)
                 expect(input.prop('aria-describedby')).toBe(undefined)
                 expect(input.prop('disabled')).toBe(defaultProps.disabled)
+                expect(input.prop('required')).toBe(false)
             })
 
             test('prop value is not empty when state.inputValue is defined', () => {

--- a/src/components/CustomFormFields/tests/CustomDateTimeField.test.js
+++ b/src/components/CustomFormFields/tests/CustomDateTimeField.test.js
@@ -42,6 +42,7 @@ describe('CustomDateTimeField', () => {
             expect(datePicker.prop('onChange')).toBeDefined()
             expect(datePicker.prop('minDate')).toBe(defaultProps.minDate)
             expect(datePicker.prop('maxDate')).toBe(defaultProps.maxDate)
+            expect(datePicker.prop('required')).toBe(false)
         })
 
         test('ValidationPopover with correct props', () => {

--- a/src/components/FormFields/index.js
+++ b/src/components/FormFields/index.js
@@ -339,6 +339,7 @@ class FormFields extends React.Component {
                                     label={<FormattedMessage  id="event-starting-datetime" />}
                                     setDirtyState={this.props.setDirtyState}
                                     maxDate={values['end_time'] ? moment(values['end_time']) : undefined}
+                                    required={true}
                                 />
                             </div>
                             <div className="col-xs-12 col-sm-12">

--- a/src/components/HelFormFields/NewEvent.js
+++ b/src/components/HelFormFields/NewEvent.js
@@ -15,6 +15,7 @@ const NewEvent = ({event, eventKey, errors, deleteSubEvent}) => (
                 defaultValue={event.start_time}
                 eventKey={eventKey}
                 validationErrors={errors['start_time']}
+                required={true}
             />
             <CustomDateTimeField
                 disablePast


### PR DESCRIPTION
Changed event start time to be a required field.
Added ability to mark date time fields as required.