### PR TITLE
Feature/lin65 pagingnumber

### DIFF
--- a/src/components/EventTable/CustomTablePagination/index.js
+++ b/src/components/EventTable/CustomTablePagination/index.js
@@ -50,6 +50,7 @@ function CustomTablePagination({count, rowsPerPage, rowsPerPageOptions, page, on
                         className="visually-hidden"
                     >
                         {intl.formatMessage({id: 'table-pagination-results'}, {from, to, count})}
+                        {intl.formatMessage({id: 'table-events-page-number'}) + '' + (page + 1)}
                     </p>
                     <p aria-hidden>{labelDisplayedRows({from, to, count})}</p>
                     <PageChangeButtons

--- a/src/components/EventTable/CustomTablePagination/index.js
+++ b/src/components/EventTable/CustomTablePagination/index.js
@@ -49,8 +49,7 @@ function CustomTablePagination({count, rowsPerPage, rowsPerPageOptions, page, on
                         role="status"
                         className="visually-hidden"
                     >
-                        {intl.formatMessage({id: 'table-pagination-results'}, {from, to, count})}
-                        {intl.formatMessage({id: 'table-events-page-number'}) + '' + (page + 1)}
+                        {intl.formatMessage({id: 'table-pagination-results'}, {from, to, count}) + ' ' + intl.formatMessage({id: 'table-events-page-number'}) + ' ' + (page + 1)}
                     </p>
                     <p aria-hidden>{labelDisplayedRows({from, to, count})}</p>
                     <PageChangeButtons

--- a/src/components/EventTable/CustomTablePagination/tests/CustomTablePagination.test.js
+++ b/src/components/EventTable/CustomTablePagination/tests/CustomTablePagination.test.js
@@ -101,11 +101,13 @@ describe('CustomTablePagination', () => {
             })
         })
 
-        test('visually hidden table pagination results', () => {
+        test('visually hidden table pagination results & table page number', () => {
             const paginationResults = getWrapper().find('.visually-hidden')
+            const tableResults = intl.formatMessage({id:'table-pagination-results'}, {from: 1, to: 25, count: 35})
+            const tableNumber = intl.formatMessage({id:'table-events-page-number'}) + ' ' + (defaultProps.page + 1)
             expect(paginationResults.length).toBe(1)
             expect(paginationResults.prop('role')).toBe('status')
-            expect(paginationResults.text()).toEqual(intl.formatMessage({id: 'table-pagination-results'}, {from: 1, to: 25, count: 35}))
+            expect(paginationResults.text()).toEqual(tableResults + ' ' + tableNumber)
         })
 
         test('aria hidden displayed rows label', () => {

--- a/src/components/ImagePicker/__snapshots__/ImagePicker.test.js.snap
+++ b/src/components/ImagePicker/__snapshots__/ImagePicker.test.js.snap
@@ -310,6 +310,7 @@ exports[`Image add form ImagePicker component should render correctly with data 
       "sunday": "sunnuntai",
       "super-event-of-series": "Tämä on tapahtumasarjan ylätapahtuma.",
       "super-event-of-umbrella": "Tämä tapahtuma on kattotapahtuma.",
+      "table-events-page-number": "Taulukon sivunumero",
       "table-events-per-page": "Tapahtumia per sivu",
       "table-pagination-next-page": "Seuraava sivu",
       "table-pagination-previous-page": "Edellinen sivu",

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -334,6 +334,7 @@
     "moderation-page-published-description": "Drafts published under an existing umbrella event will not be shown here.",
 
     "table-events-per-page": "Events per page",
+    "table-events-page-number": "Table page number",
 
     "draft-cancel": "Event drafts can't be cancelled.",
     "draft-publish-subevent": "A sub event of a series cannot be published.",

--- a/src/i18n/fi.json
+++ b/src/i18n/fi.json
@@ -339,6 +339,7 @@
     "moderation-page-published-description": "Jos julkaisit tapahtumaehdotuksen valmiin kattotapahtuman alle, sitä ei näytetä tässä näkymässä.",
 
     "table-events-per-page": "Tapahtumia per sivu",
+    "table-events-page-number": "Taulukon sivunumero",
 
     "draft-cancel": "Tapahtumaluonnoksia ei voi perua.",
     "draft-publish-subevent": "Sarjan alatapahtumia ei voi julkaista.",

--- a/src/views/EventListing/__snapshots__/EventListing.test.js.snap
+++ b/src/views/EventListing/__snapshots__/EventListing.test.js.snap
@@ -371,6 +371,7 @@ exports[`EventListing Snapshot should render view correctly 1`] = `
       "sunday": "sunnuntai",
       "super-event-of-series": "Tämä on tapahtumasarjan ylätapahtuma.",
       "super-event-of-umbrella": "Tämä tapahtuma on kattotapahtuma.",
+      "table-events-page-number": "Taulukon sivunumero",
       "table-events-per-page": "Tapahtumia per sivu",
       "table-pagination-next-page": "Seuraava sivu",
       "table-pagination-previous-page": "Edellinen sivu",

--- a/src/views/Search/__snapshots__/Search.test.js.snap
+++ b/src/views/Search/__snapshots__/Search.test.js.snap
@@ -310,6 +310,7 @@ exports[`Search Snapshot should render view correctly 1`] = `
       "sunday": "sunnuntai",
       "super-event-of-series": "Tämä on tapahtumasarjan ylätapahtuma.",
       "super-event-of-umbrella": "Tämä tapahtuma on kattotapahtuma.",
+      "table-events-page-number": "Taulukon sivunumero",
       "table-events-per-page": "Tapahtumia per sivu",
       "table-pagination-next-page": "Seuraava sivu",
       "table-pagination-previous-page": "Edellinen sivu",


### PR DESCRIPTION
Updated snapshots
Updated test
Added  {intl.formatMessage({id: 'table-pagination-results'}, {from, to, count}) + ' ' + intl.formatMessage({id: 'table-events-page-number'}) + ' ' + (page + 1)} to status for screenreader to read current page number. (page +1) so paging starts from 1 rather than from 0