### PR TITLE
Feature/new offer length

### DIFF
--- a/src/components/HelFormFields/HelOffersField.js
+++ b/src/components/HelFormFields/HelOffersField.js
@@ -5,11 +5,11 @@ import {FormattedMessage, injectIntl} from 'react-intl'
 import HelCheckbox from './HelCheckbox'
 import NewOffer from './NewOffer'
 import './HelOffersField.scss'
-
 import {Button} from 'reactstrap';
-
+import constants from '../../constants'
 import {addOffer, setOfferData, setFreeOffers} from 'src/actions/editor.js'
 
+const {GENERATE_LIMIT} = constants;
 class HelOffersField extends React.Component {
 
     static contextTypes = {
@@ -23,7 +23,6 @@ class HelOffersField extends React.Component {
         if (this.props.defaultValue && this.props.defaultValue.length > 0) {
             isFreeEvent = false //we have length in defaultvalue array so we have prices -> not a free event.
         }
-
         this.state = {
             values: this.props.defaultValue,
             isFree: isFreeEvent,
@@ -83,6 +82,8 @@ class HelOffersField extends React.Component {
 
     render() {
         const offerDetails = this.generateOffers(this.props.defaultValue)
+        //Change OFFER_LENGTH in constants to change maxium length of prices users can add, currently limited to 20
+        const isOverLimit = offerDetails.length >= GENERATE_LIMIT.OFFER_LENGTH
 
         return (
             <div className="offers-field">
@@ -93,12 +94,16 @@ class HelOffersField extends React.Component {
                 <Button
                     size='lg'block
                     variant="contained"
-                    disabled={this.state.isFree}
+                    disabled={this.state.isFree || isOverLimit}
                     onClick={() => this.addNewOffer()}
-                ><span  className="glyphicon glyphicon-plus"></span>
+                ><span aria-hidden className="glyphicon glyphicon-plus"></span>
                     <FormattedMessage id="event-add-price" />
-                    
                 </Button>
+                {isOverLimit && 
+                    <p className='OffersLimit' role='alert'>
+                        <FormattedMessage id="event-add-price-limit"/>
+                    </p>
+                }
             </div>
         )
     }

--- a/src/components/HelFormFields/HelOffersField.scss
+++ b/src/components/HelFormFields/HelOffersField.scss
@@ -6,4 +6,8 @@
     button {
         margin: 0;
     }
+    .OffersLimit {
+        margin-top: 0.5rem;
+        color: red;
+    }
 }

--- a/src/components/ImagePicker/__snapshots__/ImagePicker.test.js.snap
+++ b/src/components/ImagePicker/__snapshots__/ImagePicker.test.js.snap
@@ -112,6 +112,7 @@ exports[`Image add form ImagePicker component should render correctly with data 
       "event-action-save-new-active": "Julkaistaan tapahtumaa",
       "event-add-new-occasion": "Lisää uusi ajankohta",
       "event-add-price": "Lisää uusi hintatieto",
+      "event-add-price-limit": "Hintatietoja voi olla enintään 20 kappaletta.",
       "event-add-recurring": "Toistuva tapahtuma",
       "event-canceled": "Peruttuja tapahtumia ei voi muokata.",
       "event-categorization": "Tapahtuman luokittelu",

--- a/src/constants.js
+++ b/src/constants.js
@@ -149,6 +149,11 @@ const constants = {
         LONG_STRING: 5000,
     },
 
+    GENERATE_LIMIT: {
+        OFFER_LENGTH: 20,
+        EVENT_LENGTH: 65,
+    },
+
     USER_TYPE: {
         ADMIN: 'admin',
         REGULAR: 'regular',

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -127,6 +127,7 @@
     "event-add-recurring": "Recurring event",
     "event-delete-recurring": "Delete this occurrance",
     "event-add-price": "Add new price",
+    "event-add-price-limit": "Price information can be up to 20 pieces.",
     "date": "Date",
     "time": "Time",
     "monday": "Monday",

--- a/src/i18n/fi.json
+++ b/src/i18n/fi.json
@@ -129,6 +129,7 @@
     "event-add-recurring": "Toistuva tapahtuma",
     "event-delete-recurring": "Poista tämä tapahtumakerta",
     "event-add-price": "Lisää uusi hintatieto",
+    "event-add-price-limit": "Hintatietoja voi olla enintään 20 kappaletta.",
     "date": "Päivämäärä",
     "time": "Aika",
     "monday": "maanantai",

--- a/src/i18n/sv.json
+++ b/src/i18n/sv.json
@@ -123,6 +123,7 @@
     "event-add-recurring": "Återkommande händelse",
     "event-delete-recurring": "Radera denna förekomst av återkommande händelsen",
     "event-add-price": "Lägg till ny prisdetalj",
+    "event-add-price-limit": "Prisinformation kan vara upp till 20 stycken.",
     "date": "Datumn",
     "time": "Tid",
     "monday": "måndag",

--- a/src/views/EventListing/__snapshots__/EventListing.test.js.snap
+++ b/src/views/EventListing/__snapshots__/EventListing.test.js.snap
@@ -173,6 +173,7 @@ exports[`EventListing Snapshot should render view correctly 1`] = `
       "event-action-save-new-active": "Julkaistaan tapahtumaa",
       "event-add-new-occasion": "Lisää uusi ajankohta",
       "event-add-price": "Lisää uusi hintatieto",
+      "event-add-price-limit": "Hintatietoja voi olla enintään 20 kappaletta.",
       "event-add-recurring": "Toistuva tapahtuma",
       "event-canceled": "Peruttuja tapahtumia ei voi muokata.",
       "event-categorization": "Tapahtuman luokittelu",

--- a/src/views/Search/__snapshots__/Search.test.js.snap
+++ b/src/views/Search/__snapshots__/Search.test.js.snap
@@ -112,6 +112,7 @@ exports[`Search Snapshot should render view correctly 1`] = `
       "event-action-save-new-active": "Julkaistaan tapahtumaa",
       "event-add-new-occasion": "Lisää uusi ajankohta",
       "event-add-price": "Lisää uusi hintatieto",
+      "event-add-price-limit": "Hintatietoja voi olla enintään 20 kappaletta.",
       "event-add-recurring": "Toistuva tapahtuma",
       "event-canceled": "Peruttuja tapahtumia ei voi muokata.",
       "event-categorization": "Tapahtuman luokittelu",


### PR DESCRIPTION
Added limit of 20 to offers (can be changed from constants)
Added red-colored alert-message when limit is exceeded
Added placeholders for translations
---
Updated snapshots