### PR TITLE
Initial localization language change

### DIFF
--- a/src/components/Header/index.js
+++ b/src/components/Header/index.js
@@ -22,6 +22,7 @@ import {get} from 'lodash';
 import moment from 'moment';
 import * as momentTimezone from 'moment-timezone';
 import userManager from '../../utils/userManager';
+import {saveLocaleToLocalStorage} from '../../utils/locale';   
 
 const {USER_TYPE, APPLICATION_SUPPORT_TRANSLATION} = constants;
 
@@ -71,6 +72,7 @@ class HeaderBar extends React.Component {
         this.props.setLocale(selectedOption.value);
         moment.locale(selectedOption.value);
         momentTimezone.locale(selectedOption.value);
+        saveLocaleToLocalStorage(selectedOption.value);
     };
 
     handleLoginClick = () => {

--- a/src/reducers/userLocale.js
+++ b/src/reducers/userLocale.js
@@ -7,16 +7,13 @@ let browserLanguage = (navigator.language || navigator.userLanguage).toLowerCase
 let defaultLocale = loadLocaleFromLocalStorage();
 
 if (typeof defaultLocale === 'undefined') {
+    defaultLocale = DEFAULT_LOCALE;
     for (const locale of APPLICATION_SUPPORT_TRANSLATION) {
         if (browserLanguage.includes(locale)) {
             defaultLocale = locale;
             break;
         }
     }
-}
-
-if (typeof defaultLocale === 'undefined') {
-    defaultLocale = DEFAULT_LOCALE;
 }
 
 const initialState = {

--- a/src/reducers/userLocale.js
+++ b/src/reducers/userLocale.js
@@ -1,14 +1,24 @@
 import CONSTANTS from '../constants'
 
-const {LOCALE_ACTIONS, DEFAULT_LOCALE} = CONSTANTS
+const {LOCALE_ACTIONS, DEFAULT_LOCALE, APPLICATION_SUPPORT_TRANSLATION} = CONSTANTS
+
+let browserLanguage = (navigator.language || navigator.userLanguage).toLowerCase();
+let defaultLocale = DEFAULT_LOCALE;
+
+for (const locale of APPLICATION_SUPPORT_TRANSLATION) {
+    if (browserLanguage.includes(locale)) {
+        defaultLocale = locale;
+        break;
+    }
+}
 
 const initialState = {
-    locale: DEFAULT_LOCALE,
+    locale: defaultLocale,
 }
 
 const userLocale = (state = initialState, action) => {
     switch(action.type) {
-        case LOCALE_ACTIONS.LOCALE_SET: 
+        case LOCALE_ACTIONS.LOCALE_SET:
             return Object.assign({}, state, {
                 locale: action.locale,
             })

--- a/src/reducers/userLocale.js
+++ b/src/reducers/userLocale.js
@@ -1,15 +1,22 @@
 import CONSTANTS from '../constants'
+import {loadLocaleFromLocalStorage} from '../utils/locale'
 
 const {LOCALE_ACTIONS, DEFAULT_LOCALE, APPLICATION_SUPPORT_TRANSLATION} = CONSTANTS
 
 let browserLanguage = (navigator.language || navigator.userLanguage).toLowerCase();
-let defaultLocale = DEFAULT_LOCALE;
+let defaultLocale = loadLocaleFromLocalStorage();
 
-for (const locale of APPLICATION_SUPPORT_TRANSLATION) {
-    if (browserLanguage.includes(locale)) {
-        defaultLocale = locale;
-        break;
+if (typeof defaultLocale === 'undefined') {
+    for (const locale of APPLICATION_SUPPORT_TRANSLATION) {
+        if (browserLanguage.includes(locale)) {
+            defaultLocale = locale;
+            break;
+        }
     }
+}
+
+if (typeof defaultLocale === 'undefined') {
+    defaultLocale = DEFAULT_LOCALE;
 }
 
 const initialState = {

--- a/src/utils/locale.js
+++ b/src/utils/locale.js
@@ -21,3 +21,36 @@ export function getStringWithLocale(obj, fieldPath = '', locale = 'fi', defaultV
 
     return defaultValue
 }
+
+/**
+ * Save locale to localStorage
+ * @example
+ * localStorage.setItem('userLocale',locale)
+ * @param {string} locale
+ * @returns {void|undefined}
+ */
+export function saveLocaleToLocalStorage(locale) {
+    try {
+        return locale && typeof locale === 'string' ? localStorage.setItem('userLocale', locale) : undefined;
+    } catch(err) {
+        return undefined;
+    }
+}
+
+/**
+ * Load locale from localStorage
+ * @example
+ * localStorage.getItem('userLocale')
+ * @returns {string|undefined}
+ */
+export function loadLocaleFromLocalStorage() {
+    try {
+        const locale = localStorage.getItem('userLocale');
+        if (locale === null) {
+            return undefined;
+        }
+        return locale;
+    } catch(err) {
+        return undefined;
+    }
+}


### PR DESCRIPTION
Functionality that sets browser language as the initial language, when manually changed, it will store that data and use the selected language instead.
If localization is not found, use default language (fi).
Worked with: @hienous