### PR TITLE
Fixed events created by user pagination.

### DIFF
--- a/src/views/EventListing/index.js
+++ b/src/views/EventListing/index.js
@@ -168,8 +168,16 @@ export class EventListing extends React.Component {
      */
     toggleUserEvents = (event) => {
         const showCreatedByUser = event.target.checked
-        this.setState({showCreatedByUser}, this.fetchTableData)
-    }
+        this.setState(state => ({
+            showCreatedByUser: showCreatedByUser,
+            tableData: {
+                ...state.tableData,
+                paginationPage: 0,
+            }}),
+        this.fetchTableData
+        )};
+        
+
 
     /**
      * Toggles whether events based on language should be shown


### PR DESCRIPTION
Pagination didn't reset when going to page 2 and selecting "Show only events created by "me"". Fixed that.