### PR TITLE
Removed tabIndexes and general accessibility fixes

### DIFF
--- a/src/components/EventActionButton/EventActionButton.js
+++ b/src/components/EventActionButton/EventActionButton.js
@@ -102,12 +102,6 @@ class EventActionButton extends React.Component {
             <Fragment>
                 {showTermsCheckbox &&
                 <div className='terms-checkbox'>
-                    <Input
-                        type='checkbox'
-                        checked={this.state.agreedToTerms}
-                        onChange={this.handleChange}
-                        id='terms-agree'
-                    />
                     <label htmlFor='terms-agree'>
                         <FormattedMessage id={'terms-agree-text'}>{txt => txt}</FormattedMessage>
                         &nbsp;
@@ -115,6 +109,12 @@ class EventActionButton extends React.Component {
                             <FormattedMessage id={'terms-agree-link'}>{txt => txt}</FormattedMessage>
                         </Link>
                     </label>
+                    <Input
+                        type='checkbox'
+                        checked={this.state.agreedToTerms}
+                        onChange={this.handleChange}
+                        id='terms-agree'
+                    />
                 </div>
                 }
                 <Button
@@ -133,7 +133,6 @@ class EventActionButton extends React.Component {
                         <FormattedMessage id={explanationId}>{txt => txt}</FormattedMessage>
                     </UncontrolledTooltip>
                 }
-
             </Fragment>
         )
     }

--- a/src/components/EventDetails/index.scss
+++ b/src/components/EventDetails/index.scss
@@ -104,7 +104,7 @@ legend {
 }
 
 .no-value {
-    color: #777;
+    color: #757575;
     font-style: italic;
     font-weight: 300;
 }

--- a/src/components/FormFields/index.js
+++ b/src/components/FormFields/index.js
@@ -35,7 +35,7 @@ import ImageGallery from '../ImageGallery/ImageGallery';
 
 let FormHeader = (props) => (
     <div className="row">
-        <h2 tabIndex='0' className="col-sm-12">{ props.children }</h2>
+        <h2 className="col-sm-12">{ props.children }</h2>
     </div>
 )
 
@@ -44,7 +44,7 @@ FormHeader.propTypes = {
 }
 
 export const SideField = (props) => (
-    <div className={`side-field col-sm-5 col-sm-push-1 ${ props.className }`} aria-label='text' tabIndex='0'>
+    <div className={`side-field col-sm-5 col-sm-push-1 ${ props.className }`} aria-label='text'>
         { props.children }
     </div>
 )

--- a/src/components/HelFormFields/HelKeywordSelector/HelKeywordSelector.js
+++ b/src/components/HelFormFields/HelKeywordSelector/HelKeywordSelector.js
@@ -128,8 +128,8 @@ const HelKeywordSelector = ({intl, editor, setDirtyState, setData, currentLocale
                     }
                     currentLocale={currentLocale}
                 />
-                <CopyToClipboard text={values['keywords'] ? getKeywordIds(keywords) : ''}>
-                    <button type='button' className="clipboard-copy-button btn btn-default" aria-label={intl.formatMessage({id: 'copy-keyword-to-clipboard'})} aria-hidden='true'>
+                <CopyToClipboard tabindex='-1' aria-hidden='true' text={values['keywords'] ? getKeywordIds(keywords) : ''}>
+                    <button type='button' className="clipboard-copy-button btn btn-default" aria-label={intl.formatMessage({id: 'copy-keyword-to-clipboard'})}>
                         <span className="glyphicon glyphicon-duplicate" aria-hidden="true"></span>
                         <p hidden>duplicate</p>
                     </button>

--- a/src/views/Editor/index.scss
+++ b/src/views/Editor/index.scss
@@ -133,10 +133,10 @@ $actionBtnHeight: 60px;
                 }
                 input {
                     position: unset;
-                    margin: 0;
+                    margin: 0 0.7em 0 0;
                 }
                 label {
-                    margin: 0 0 0 1em;
+                    margin: 0 1em 0 0;
                 }
             }
         }


### PR DESCRIPTION
Removed unnecessary tabIndexes, increased 'Check data in the form' text contrast level and changed agree to terms checkbox to be after the informative text.
Copy to clipboard is now hidden and no longer accessible with tab. Functionality wise, it doesn't bring enough value to the form.