### PR TITLE
Added auto focus on new date and price fields

### DIFF
--- a/src/components/CustomFormFields/Dateinputs/CustomDateTime.js
+++ b/src/components/CustomFormFields/Dateinputs/CustomDateTime.js
@@ -34,6 +34,8 @@ class CustomDateTime extends React.Component {
         this.handleDateTimePickerChange = this.handleDateTimePickerChange.bind(this)
         this.handleDataUpdate = this.handleDataUpdate.bind(this)
         this.validateDate = this.validateDate.bind(this)
+
+        this.firstInput = React.createRef()
     }
     
     static contextTypes = {
@@ -112,6 +114,12 @@ class CustomDateTime extends React.Component {
         return true
     }
 
+    componentDidMount(){
+        if(this.props.setInitialFocus){
+            this.firstInput.current.focus()
+        }
+    }
+
     componentDidUpdate(prevProps) {
         // Update validation if min or max date changes and dateInputValue and timeInputValue are not empty
         const {minDate, maxDate} = this.props
@@ -167,6 +175,7 @@ class CustomDateTime extends React.Component {
                                 onBlur={this.handleInputBlur}
                                 disabled={disabled}
                                 required={required}
+                                innerRef={this.firstInput}
                             />
                             <ValidationPopover
                                 anchor={this.containerRef}
@@ -242,6 +251,7 @@ CustomDateTime.propTypes = {
     required: PropTypes.bool,
     setDirtyState: PropTypes.func,
     setData: PropTypes.func,
+    setInitialFocus: PropTypes.bool,
     updateSubEvent: PropTypes.func,
     eventKey: PropTypes.string,
     intl: PropTypes.object,

--- a/src/components/CustomFormFields/Dateinputs/tests/CustomDateTime.test.js
+++ b/src/components/CustomFormFields/Dateinputs/tests/CustomDateTime.test.js
@@ -32,6 +32,7 @@ const defaultProps = {
     maxDate: moment('2020-04-23'),
     getDateFormat: () => {},
     required: true,
+    setInitialFocus: false,
 }
 const typeFieldId = ['-date-field', '-time-field']
 
@@ -353,7 +354,25 @@ describe('functions', () => {
         })
     })
 
+    describe('componentDidMount', () => {
+        test('sets focus to ref firstInput if prop.setInitialFocus is true', () => {
+            const wrapper = mount(<UnconnectedCustomDateTime {...defaultProps} setInitialFocus={true} />, {context: {intl}});
+            const instance = wrapper.instance()
+            const firstInput = instance.firstInput
+            jest.spyOn(firstInput.current, 'focus')
+            instance.componentDidMount()
+            expect(firstInput.current.focus).toHaveBeenCalledTimes(1)
+        })
 
+        test('doesnt set focus to firstInput if prop.setInitialFocus is not true', () => {
+            const wrapper = mount(<UnconnectedCustomDateTime {...defaultProps} setInitialFocus={false} />, {context: {intl}});
+            const instance = wrapper.instance()
+            const firstInput = instance.firstInput
+            jest.spyOn(firstInput.current, 'focus')
+            instance.componentDidMount()
+            expect(firstInput.current.focus).toHaveBeenCalledTimes(0)
+        })
+    })
 
     describe('componentDidUpdate', () => {
         const spy = jest.spyOn(UnconnectedCustomDateTime.prototype, 'validateDate');

--- a/src/components/FormFields/index.js
+++ b/src/components/FormFields/index.js
@@ -163,6 +163,9 @@ class FormFields extends React.Component {
         const subEventErrors = validationErrors.sub_events || {}
 
         let newEvents = []
+        const keys = Object.keys(events)
+        const lastKey = keys[keys.length - 1]
+
         for (const key in events) {
             if (events.hasOwnProperty(key)) {
                 newEvents.push(
@@ -171,6 +174,7 @@ class FormFields extends React.Component {
                         eventKey={key}
                         event={events[key]}
                         errors={subEventErrors[key] || {}}
+                        setInitialFocus={key === lastKey ? true : false}
                     />
                 )
             }

--- a/src/components/HelFormFields/HelOffersField.js
+++ b/src/components/HelFormFields/HelOffersField.js
@@ -63,6 +63,13 @@ class HelOffersField extends React.Component {
 
     generateOffers(offers) {
         const newOffers = []
+        let keys
+        let lastKey
+        if(offers){
+            keys = Object.keys(offers)
+            lastKey = keys[keys.length - 1]
+        }
+
         for (const key in offers) {
             if (offers.hasOwnProperty(key) && !this.state.isFree) {
                 newOffers.push(
@@ -73,6 +80,7 @@ class HelOffersField extends React.Component {
                         validationErrors={this.props.validationErrors}
                         languages={this.props.languages}
                         isFree={this.state.isFree}
+                        setInitialFocus={key === lastKey ? true : false}
                     />
                 )
             }

--- a/src/components/HelFormFields/HelTextField.js
+++ b/src/components/HelFormFields/HelTextField.js
@@ -27,6 +27,10 @@ class HelTextField extends Component {
 
     componentDidMount() {
         this.setValidationErrorsToState();
+
+        if(this.props.setInitialFocus){
+            this.inputRef.focus()
+        }
     }
 
     UNSAFE_componentWillReceiveProps(nextProps) {
@@ -249,6 +253,7 @@ HelTextField.propTypes = {
         PropTypes.string,
         PropTypes.number,
     ]),
+    setInitialFocus: PropTypes.bool,
 }
 
 HelTextField.defaultProps = {

--- a/src/components/HelFormFields/MultiLanguageField.js
+++ b/src/components/HelFormFields/MultiLanguageField.js
@@ -49,6 +49,7 @@ class MultiLanguageField extends React.Component {
         label: PropTypes.string,
         id: PropTypes.string,
         type: PropTypes.string,
+        setInitialFocus: PropTypes.bool,
     }
 
     onChange(e,value,lang) {
@@ -140,6 +141,7 @@ class MultiLanguageField extends React.Component {
                         index={this.props.index}
                         multiLine={this.props.multiLine}
                         type={this.props.type}
+                        setInitialFocus={this.props.setInitialFocus}
                     />
 
                 </div>
@@ -160,6 +162,7 @@ class MultiLanguageField extends React.Component {
                             disabled={this.props.disabled}
                             validations={this.props.validations}
                             type={this.props.type}
+                            setInitialFocus={this.props.setInitialFocus && (index === 0)}
                         />
                     </div>
                 )

--- a/src/components/HelFormFields/NewEvent.js
+++ b/src/components/HelFormFields/NewEvent.js
@@ -5,7 +5,7 @@ import CustomDateTime from '../CustomFormFields/Dateinputs/CustomDateTime';
 import {connect} from 'react-redux'
 import {deleteSubEvent as deleteSubEventAction} from 'src/actions/editor'
 import {FormattedMessage, injectIntl} from 'react-intl';
-const NewEvent = ({event, eventKey, errors, deleteSubEvent, intl}) => (
+const NewEvent = ({event, eventKey, errors, deleteSubEvent, intl, setInitialFocus}) => (
     <div className="new-sub-event">
         <div className="new-sub-event--inputs">
             <CustomDateTime
@@ -17,6 +17,7 @@ const NewEvent = ({event, eventKey, errors, deleteSubEvent, intl}) => (
                 eventKey={eventKey}
                 validationErrors={errors['start_time']}
                 required={true}
+                setInitialFocus={setInitialFocus}
             />
             <CustomDateTime
                 disablePast
@@ -49,6 +50,7 @@ NewEvent.propTypes = {
     errors: PropTypes.object,
     deleteSubEvent: PropTypes.func,
     intl: PropTypes.object,
+    setInitialFocus: PropTypes.bool,
 }
 
 

--- a/src/components/HelFormFields/NewOffer.js
+++ b/src/components/HelFormFields/NewOffer.js
@@ -100,7 +100,8 @@ class NewOffer extends React.Component {
                     multiLine={true} 
                     onBlur={e => this.onBlur(e)} 
                     validationErrors={this.props.validationErrors['offer_description']} 
-                    index={this.props.offerKey} 
+                    index={this.props.offerKey}
+                    setInitialFocus={this.props.setInitialFocus}
                 />
 
                 <MultiLanguageField
@@ -140,6 +141,7 @@ NewOffer.propTypes = {
     id: PropTypes.string,
     label: PropTypes.string,
     intl: intlShape,
+    setInitialFocus: PropTypes.bool,
 }
 
 export default injectIntl(NewOffer);

--- a/src/components/HelFormFields/tests/HelTextField.test.js
+++ b/src/components/HelFormFields/tests/HelTextField.test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import {shallow} from 'enzyme';
+import {shallow, mount} from 'enzyme';
 import HelTextField from '../HelTextField';
 import {Input, FormText} from 'reactstrap';
 import ValidationPopover from '../../ValidationPopover';
@@ -27,6 +27,7 @@ const defaultProps = {
     validationErrors: undefined,
     type: 'text',
     index: 'text-index',
+    setInitialFocus: false,
 }
 
 describe('HelTextField', () => {
@@ -108,12 +109,33 @@ describe('HelTextField', () => {
     })
 
     describe('functions', () => {
-        test('componentDidMount', () => {
-            const instance = getWrapper().instance()
-            jest.spyOn(instance, 'setValidationErrorsToState')
-            instance.componentDidMount()
-            expect(instance.setValidationErrorsToState).toHaveBeenCalledTimes(1)
+        describe('componentDidMount', () => {
+            test('calls setValidationErrorsToState', () => {
+                const instance = getWrapper().instance()
+                jest.spyOn(instance, 'setValidationErrorsToState')
+                instance.componentDidMount()
+                expect(instance.setValidationErrorsToState).toHaveBeenCalledTimes(1)
+            })
+
+            test('sets focus to ref inputRef if prop.setInitialFocus is true', () => {
+                const wrapper = mount(<HelTextField {...defaultProps} setInitialFocus={true} />, {context: {intl}});
+                const instance = wrapper.instance()
+                const inputRef = instance.inputRef
+                jest.spyOn(inputRef, 'focus')
+                instance.componentDidMount()
+                expect(inputRef.focus).toHaveBeenCalledTimes(1)
+            })
+    
+            test('doesnt set focus to inputRef if prop.setInitialFocus is not true', () => {
+                const wrapper = mount(<HelTextField {...defaultProps} setInitialFocus={false} />, {context: {intl}});
+                const instance = wrapper.instance()
+                const inputRef = instance.inputRef
+                jest.spyOn(inputRef, 'focus')
+                instance.componentDidMount()
+                expect(inputRef.focus).toHaveBeenCalledTimes(0)
+            })
         })
+        
 
         describe('UNSAFE_componentWillReceiveProps', () => {
             test('sets state.value when props.defaultValue changes', () => {


### PR DESCRIPTION
Adding new date and price form elements moves the focus on them instead of staying on the add button.