### PR TITLE
Replaced input required with aria-required

### DIFF
--- a/src/components/CustomFormFields/Dateinputs/CustomDatePicker.js
+++ b/src/components/CustomFormFields/Dateinputs/CustomDatePicker.js
@@ -194,7 +194,7 @@ class CustomDatePicker extends React.Component {
                             onChange={this.handleInputChange}
                             onBlur={this.handleInputBlur}
                             disabled={disabled}
-                            required={required}
+                            aria-required={required}
                         />
                         <DatePicker
                             disabled={disabled}

--- a/src/components/CustomFormFields/Dateinputs/CustomDateTime.js
+++ b/src/components/CustomFormFields/Dateinputs/CustomDateTime.js
@@ -174,7 +174,7 @@ class CustomDateTime extends React.Component {
                                 onChange={this.handleInputChangeDate}
                                 onBlur={this.handleInputBlur}
                                 disabled={disabled}
-                                required={required}
+                                aria-required={required}
                                 innerRef={this.firstInput}
                             />
                             <ValidationPopover
@@ -217,7 +217,7 @@ class CustomDateTime extends React.Component {
                                 onChange={this.handleInputChangeTime}
                                 onBlur={this.handleInputBlur}
                                 disabled={disabled}
-                                required={required}
+                                aria-required={required}
                             />
                             <ValidationPopover
                                 anchor={this.containerRef}

--- a/src/components/CustomFormFields/Dateinputs/tests/CustomDatePicker.test.js
+++ b/src/components/CustomFormFields/Dateinputs/tests/CustomDatePicker.test.js
@@ -69,7 +69,7 @@ describe('CustomDatePicker', () => {
                 expect(input.prop('onBlur')).toBe(instance.handleInputBlur)
                 expect(input.prop('aria-describedby')).toBe(undefined)
                 expect(input.prop('disabled')).toBe(defaultProps.disabled)
-                expect(input.prop('required')).toBe(false)
+                expect(input.prop('aria-required')).toBe(false)
             })
 
             test('prop value is not empty when state.inputValue is defined', () => {

--- a/src/components/CustomFormFields/Dateinputs/tests/CustomDateTime.test.js
+++ b/src/components/CustomFormFields/Dateinputs/tests/CustomDateTime.test.js
@@ -77,7 +77,7 @@ describe('renders', () => {
                 expect(element.prop('onBlur')).toBe(instance.handleInputBlur)
                 expect(element.prop('aria-describedby')).toBe(undefined)
                 expect(element.prop('disabled')).toBe(defaultProps.disabled)
-                expect(element.prop('required')).toBe(defaultProps.required)
+                expect(element.prop('aria-required')).toBe(defaultProps.required)
                 expect(element.prop('id')).toBe(defaultProps.id + typeFieldId[index])
             });
             expect(input.at(0).prop('value')).toBe(instance.state.dateInputValue)

--- a/src/components/HelFormFields/HelTextField.js
+++ b/src/components/HelFormFields/HelTextField.js
@@ -204,7 +204,7 @@ class HelTextField extends Component {
                         type={type}
                         name={name}
                         value={value}
-                        required={required}
+                        aria-required={required}
                         onChange={this.handleChange}
                         onBlur={this.handleBlur}
                         innerRef={ref => this.inputRef = ref}

--- a/src/components/HelFormFields/tests/HelTextField.test.js
+++ b/src/components/HelFormFields/tests/HelTextField.test.js
@@ -70,7 +70,7 @@ describe('HelTextField', () => {
             expect(inputComponent.prop('type')).toBe(defaultProps.type)
             expect(inputComponent.prop('name')).toBe(defaultProps.name)
             expect(inputComponent.prop('value')).toBe(defaultProps.defaultValue)
-            expect(inputComponent.prop('required')).toBe(defaultProps.required)
+            expect(inputComponent.prop('aria-required')).toBe(defaultProps.required)
             expect(inputComponent.prop('onChange')).toBe(instance.handleChange)
             expect(inputComponent.prop('onBlur')).toBe(instance.handleBlur)
             expect(inputComponent.prop('innerRef')).toBeDefined()


### PR DESCRIPTION
Required attribute causes screen readers to announce empty fields always as faulty. Using aria-required fixes this issue.