### PR TITLE
event page style fix

### DIFF
--- a/src/components/EventDetails/index.scss
+++ b/src/components/EventDetails/index.scss
@@ -116,9 +116,15 @@ legend {
 .option-group {
     padding: $default-margin-top 0;
     label {
-        font-size: 22px;
+        font-size: 	1.375rem;
         font-weight: 300;
         text-transform: capitalize;
+    }
+    .custom-control {
+        label {
+            font-size: 1.25rem;
+            padding-top: 0.2rem;
+        }
     }
 }
 

--- a/src/views/Editor/index.scss
+++ b/src/views/Editor/index.scss
@@ -101,23 +101,7 @@ $actionBtnHeight: 60px;
                 &.editor-update-button {
                     margin-right: auto;
                 }
-            }/*
-            .terms-checkbox {
-                height: $actionBtnHeight;
-                display: flex;
-                align-items: center;
-                justify-content: center;
-                @media (max-width: 768px) {
-                    height: 30px;
-                }
-                input {
-                    position: unset;
-                    margin: 0 0.7em 0 0;
-                }
-                label {
-                    margin: 0 1em 0 0;
-                }
-            }*/
+            }
         }
     }
 }


### PR DESCRIPTION
Fixed styling for event-page checkboxes, now text aligns with the boxes.

Removed commented out styles which were no longer required.