### PR TITLE
NavLink routing fix 

### DIFF
--- a/src/components/Header/Header.test.js
+++ b/src/components/Header/Header.test.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import {shallow} from 'enzyme';
-import {NavLink, Button} from 'reactstrap';
+import {Button} from 'reactstrap';
+import {NavLink} from 'react-router-dom'
 
 import {mockUser} from '__mocks__/mockData';
 import {UnconnectedHeaderBar} from './index';
@@ -135,28 +136,16 @@ describe('components/Header/index', () => {
 
                 test('when user is admin, one of the NavLinks is to moderation', () => {
                     const element = getWrapper({user: userAdmin}).find(NavLink).filter('.moderator');
-                    expect(element.prop('className')).toBe('moderator');
+                    expect(element.prop('className')).toBe('nav-link moderator');
                 });
 
                 test('NavLink is active based on location.pathname prop',() => {
                     const element = getWrapper({location:{pathname:'/'}});
                     let navLinks = element.find(NavLink);
-                    expect(navLinks.at(0).prop('active')).toBe(false);
-                    expect(navLinks.at(1).prop('active')).toBe(false);
-                    expect(navLinks.at(2).prop('active')).toBe(true);
-                    expect(navLinks.at(3).prop('active')).toBe(false);
-                    element.setProps({location:{pathname:'/search'}});
-                    navLinks = element.find(NavLink);
-                    expect(navLinks.at(0).prop('active')).toBe(false);
-                    expect(navLinks.at(1).prop('active')).toBe(true);
-                    expect(navLinks.at(2).prop('active')).toBe(false);
-                    expect(navLinks.at(3).prop('active')).toBe(false);
-                    element.setProps({location:{pathname:'/help'}});
-                    navLinks = element.find(NavLink);
-                    expect(navLinks.at(0).prop('active')).toBe(false);
-                    expect(navLinks.at(1).prop('active')).toBe(false);
-                    expect(navLinks.at(2).prop('active')).toBe(false);
-                    expect(navLinks.at(3).prop('active')).toBe(true);
+                    expect(navLinks.at(0).prop('strict')).toBe(false);
+                    expect(navLinks.at(1).prop('strict')).toBe(false);
+                    expect(navLinks.at(2).prop('exact')).toBe(true);
+                    expect(navLinks.at(3).prop('strict')).toBe(false);
                 });
             });
         });

--- a/src/components/Header/Header.test.js
+++ b/src/components/Header/Header.test.js
@@ -146,6 +146,18 @@ describe('components/Header/index', () => {
                     expect(navLinks.at(1).prop('strict')).toBe(false);
                     expect(navLinks.at(2).prop('exact')).toBe(true);
                     expect(navLinks.at(3).prop('strict')).toBe(false);
+                    element.setProps({location:{pathname:'/search'}});
+                    navLinks = element.find(NavLink);
+                    expect(navLinks.at(0).prop('strict')).toBe(false);
+                    expect(navLinks.at(1).prop('strict')).toBe(true);
+                    expect(navLinks.at(2).prop('strict')).toBe(false);
+                    expect(navLinks.at(3).prop('strict')).toBe(false);
+                    element.setProps({location:{pathname:'/help'}});
+                    navLinks = element.find(NavLink);
+                    expect(navLinks.at(0).prop('strict')).toBe(false);
+                    expect(navLinks.at(1).prop('strict')).toBe(false);
+                    expect(navLinks.at(2).prop('strict')).toBe(false);
+                    expect(navLinks.at(3).prop('strict')).toBe(true);
                 });
             });
         });

--- a/src/components/Header/index.js
+++ b/src/components/Header/index.js
@@ -6,6 +6,7 @@ import PropTypes from 'prop-types';
 import {connect} from 'react-redux';
 import {push} from 'react-router-redux';
 import {withRouter} from 'react-router';
+import {NavLink} from 'react-router-dom'
 
 import {clearUserData as clearUserDataAction} from 'src/actions/user.js';
 import {setLocale as setLocaleAction} from 'src/actions/userLocale';
@@ -15,7 +16,7 @@ import {FormattedMessage} from 'react-intl';
 import constants from '../../constants';
 
 // Citylogo is now set from SCSS, className: bar__logo
-import {Collapse, Navbar, NavbarToggler, NavItem, NavLink, NavbarBrand, Button} from 'reactstrap';
+import {Collapse, Navbar, NavbarToggler, NavItem, Button} from 'reactstrap';
 import {hasOrganizationWithRegularUsers} from '../../utils/user';
 import {get} from 'lodash';
 import moment from 'moment';
@@ -151,8 +152,9 @@ class HeaderBar extends React.Component {
                         <ul className='linked-events-bar__links'>
                             <NavItem>
                                 <NavLink
-                                    active={this.isActivePath('/event/create/new')}
-                                    href='#'
+                                    strict={this.isActivePath('/event/create/new')}
+                                    className='nav-link'
+                                    to='/event/create/new'
                                     onClick={() => this.handleOnClick('/event/create/new')}>
                                     <span aria-hidden className='glyphicon glyphicon-plus' />
                                     <FormattedMessage id={`create-${appSettings.ui_mode}`} />
@@ -160,8 +162,9 @@ class HeaderBar extends React.Component {
                             </NavItem>
                             <NavItem>
                                 <NavLink
-                                    active={this.isActivePath('/search')}
-                                    href='#'
+                                    strict={this.isActivePath('/search')}
+                                    className='nav-link'
+                                    to='/search'
                                     onClick={() => this.handleOnClick('/search')}>
                                     <span aria-hidden className='glyphicon glyphicon-search' />
                                     <FormattedMessage id={`search-${appSettings.ui_mode}`} />
@@ -169,8 +172,9 @@ class HeaderBar extends React.Component {
                             </NavItem>
                             <NavItem>
                                 <NavLink
-                                    active={this.isActivePath('/')}
-                                    href='#'
+                                    exact
+                                    to='/'
+                                    className='nav-link'
                                     onClick={() => this.handleOnClick('/')}>
                                     <span aria-hidden className='glyphicon glyphicon-wrench' />
                                     <FormattedMessage id={`${appSettings.ui_mode}-management`} />
@@ -179,9 +183,9 @@ class HeaderBar extends React.Component {
                             {showModerationLink && (
                                 <NavItem>
                                     <NavLink
-                                        active={this.isActivePath('/moderation')}
-                                        href='#'
-                                        className='moderator'
+                                        strict={this.isActivePath('/moderation')}
+                                        className='nav-link moderator'
+                                        to='/moderation'
                                         onClick={() => this.handleOnClick('/moderation')}>
                                         <span aria-hidden className='glyphicon glyphicon-cog' />
                                         <FormattedMessage id='moderation-page' />
@@ -190,8 +194,9 @@ class HeaderBar extends React.Component {
                             )}
                             <NavItem>
                                 <NavLink
-                                    active={this.isActivePath('/help')}
-                                    href='#'
+                                    strict={this.isActivePath('/help')}
+                                    className='nav-link'
+                                    to='/help'
                                     onClick={() => this.handleOnClick('/help')}>
                                     <span aria-hidden className='glyphicon glyphicon-question-sign' />
                                     <FormattedMessage id='more-info' />

--- a/src/components/Header/index.js
+++ b/src/components/Header/index.js
@@ -172,6 +172,7 @@ class HeaderBar extends React.Component {
                             </NavItem>
                             <NavItem>
                                 <NavLink
+                                    strict={this.isActivePath('/')}
                                     exact
                                     to='/'
                                     className='nav-link'

--- a/src/components/ImagePicker/__snapshots__/ImagePicker.test.js.snap
+++ b/src/components/ImagePicker/__snapshots__/ImagePicker.test.js.snap
@@ -495,6 +495,7 @@ exports[`Image add form ImagePicker component should render view by default 1`] 
     role="dialog"
     scrollable={false}
     size="xl"
+    trapFocus={false}
     unmountOnClose={true}
     zIndex={1050}
   >

--- a/src/components/ImagePicker/__snapshots__/ImagePicker.test.js.snap
+++ b/src/components/ImagePicker/__snapshots__/ImagePicker.test.js.snap
@@ -495,7 +495,6 @@ exports[`Image add form ImagePicker component should render view by default 1`] 
     role="dialog"
     scrollable={false}
     size="xl"
-    trapFocus={false}
     unmountOnClose={true}
     zIndex={1050}
   >


### PR DESCRIPTION
Changed Reactstrap NavLinks to react-router-dom NavLinks so that href routing could work correctly.
(Opening a new window with the old NavLinks would just reopen the current window in a new tab - not the correct functionality.)