### PR TITLE
Tooltips for Calendar and CopyToClipboard

### DIFF
--- a/src/components/CustomFormFields/Dateinputs/CustomDatePicker.js
+++ b/src/components/CustomFormFields/Dateinputs/CustomDatePicker.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import DatePicker, {registerLocale} from 'react-datepicker'
 import PropTypes from 'prop-types'
-import {FormGroup, Label, Input, Button} from 'reactstrap'
+import {FormGroup, Label, Input} from 'reactstrap'
 import 'react-datepicker/dist/react-datepicker.css'
 import './CustomDatePicker.scss'
 import moment from 'moment'
@@ -197,6 +197,7 @@ class CustomDatePicker extends React.Component {
                             aria-required={required}
                         />
                         <DatePicker
+                            id={type}
                             disabled={disabled}
                             openToDate={this.getDatePickerOpenDate(defaultValue, minDate)}
                             onChange={this.handleDatePickerChange}

--- a/src/components/CustomFormFields/Dateinputs/CustomDateTime.js
+++ b/src/components/CustomFormFields/Dateinputs/CustomDateTime.js
@@ -147,6 +147,7 @@ class CustomDateTime extends React.Component {
                         <Label for={dateFieldId}>{getCorrectInputLabel(labelDate)}{required ? '*' : ''}</Label>
                         <div className="input-and-button"  ref={ref => this.containerRef = ref}>
                             <DatePicker
+                                id={dateFieldId + '-button'}
                                 disabled={disabled}
                                 onChange={(value) => this.handleDateTimePickerChange(value, 'date')}
                                 customInput={<DatePickerButton type={'date'} intl={intl} disabled={disabled} />}
@@ -188,6 +189,7 @@ class CustomDateTime extends React.Component {
                         <Label for={timeFieldId}>{getCorrectInputLabel(labelTime)}{required ? '*' : ''}</Label>
                         <div className="input-and-button"  ref={ref => this.containerRef = ref}>
                             <DatePicker
+                                id={timeFieldId + '-button'}
                                 disabled={disabled}
                                 onChange={(value) => this.handleDateTimePickerChange(value, 'time')}
                                 customInput={<DatePickerButton type={'time'} intl={intl} disabled={disabled} />}

--- a/src/components/CustomFormFields/Dateinputs/DatePickerButton.js
+++ b/src/components/CustomFormFields/Dateinputs/DatePickerButton.js
@@ -1,21 +1,27 @@
-import React from 'react'
-import PropTypes from 'prop-types'
-import {Button} from 'reactstrap'
-import {injectIntl} from 'react-intl'
+import React, {Fragment} from 'react';
+import PropTypes from 'prop-types';
+import {Button, UncontrolledTooltip} from 'reactstrap';
+import {injectIntl} from 'react-intl';
 
-function DatePickerButton ({intl, disabled, onClick, type}) {
-    const iconClass =  type !== 'time' ? 'glyphicon glyphicon-calendar' : 'glyphicon glyphicon-time'
-
+function DatePickerButton({intl, disabled, onClick, type, id}) {
+    const iconClass = type !== 'time' ? 'glyphicon glyphicon-calendar' : 'glyphicon glyphicon-time';
+    const toolTip = type !== 'time' ? intl.formatMessage({id: 'date'}) : intl.formatMessage({id: 'time'});
     return (
-        <Button
-            disabled={disabled}
-            aria-hidden
-            aria-label={intl.formatMessage({id: 'date-picker-button-label'})}
-            tabIndex={-1}
-            onClick={onClick}
-            className={'custom-date-input__button' + ' ' + iconClass}>
-        </Button>
-    )
+        <Fragment>
+            <Button
+                id={id}
+                disabled={disabled}
+                aria-hidden
+                aria-label={intl.formatMessage({id: 'date-picker-button-label'})}
+                tabIndex={-1}
+                onClick={onClick}
+                className={'custom-date-input__button' + ' ' + iconClass}
+            />
+            <UncontrolledTooltip placement='top' target={id} innerClassName='tooltip-disabled' hideArrow>
+                {toolTip}
+            </UncontrolledTooltip>
+        </Fragment>
+    );
 }
 
 DatePickerButton.propTypes = {
@@ -23,6 +29,8 @@ DatePickerButton.propTypes = {
     disabled: PropTypes.bool,
     type: PropTypes.string,
     intl: PropTypes.object,
-}
-export {DatePickerButton as UnconnectedDatePickerButton}
-export default injectIntl(DatePickerButton)
+    id: PropTypes.string,
+};
+
+export {DatePickerButton as UnconnectedDatePickerButton};
+export default injectIntl(DatePickerButton);

--- a/src/components/CustomFormFields/Dateinputs/tests/CustomDatePicker.test.js
+++ b/src/components/CustomFormFields/Dateinputs/tests/CustomDatePicker.test.js
@@ -395,7 +395,7 @@ describe('CustomDatePicker', () => {
             
             describe('calls validateDate if state.inputValue is defined', () => {
                 test('with correct params when inputValue is not valid', () => {
-                    const wrapper = mount(<CustomDatePicker {...defaultProps} />, {context: {intl}});
+                    const wrapper = shallow(<CustomDatePicker {...defaultProps} />, {context: {intl}});
                     const instance = wrapper.instance()
                     instance.state.inputValue = '123'
                     const minDate = moment('2020-03-23')
@@ -407,7 +407,7 @@ describe('CustomDatePicker', () => {
                 })
 
                 test('with correct params when inputValue is valid', () => {
-                    const wrapper = mount(<CustomDatePicker {...defaultProps} />, {context: {intl}});
+                    const wrapper = shallow(<CustomDatePicker {...defaultProps} />, {context: {intl}});
                     const instance = wrapper.instance()
                     instance.state.inputValue = '20.5.2020'
                     const minDate = moment('2020-03-23')
@@ -420,7 +420,7 @@ describe('CustomDatePicker', () => {
             })
 
             test('doesnt call validateDate if state.inputValue is not defined', () => {
-                const wrapper = mount(<CustomDatePicker {...defaultProps} />, {context: {intl}});
+                const wrapper = shallow(<CustomDatePicker {...defaultProps} />, {context: {intl}});
                 const minDate = moment('2020-03-23')
                 wrapper.setProps({minDate})
                 expect(spy).toHaveBeenCalledTimes(0);

--- a/src/components/CustomFormFields/Dateinputs/tests/CustomDateTime.test.js
+++ b/src/components/CustomFormFields/Dateinputs/tests/CustomDateTime.test.js
@@ -134,6 +134,7 @@ describe('renders', () => {
 
         test('for date with default props', () => {
             const dateDatePicker = wrapper.find(DatePicker).at(0)
+            expect(dateDatePicker.prop('id')).toBe(defaultProps.id + '-date-field' + '-button')
             expect(dateDatePicker.prop('disabled')).toBe(defaultProps.disabled)
             expect(dateDatePicker.prop('openToDate')).toEqual(getDatePickerOpenDate(defaultProps.defaultValue))
             expect(dateDatePicker.prop('onChange')).toBeDefined()
@@ -155,6 +156,7 @@ describe('renders', () => {
         test('for time with default props', () => {
             const timeDatePicker = wrapper.find(DatePicker).at(1)
             expect(timeDatePicker.prop('onChange')).toBeDefined()
+            expect(timeDatePicker.prop('id')).toBe(defaultProps.id + '-time-field' + '-button')
             expect(timeDatePicker.prop('disabled')).toBe(defaultProps.disabled)
             expect(timeDatePicker.prop('customInput')).toEqual(<DatePickerButton disabled={defaultProps.disabled} type={'time'}/>)
             expect(timeDatePicker.prop('locale')).toBe(instance.context.intl.locale)

--- a/src/components/CustomFormFields/Dateinputs/tests/CustomDateTime.test.js
+++ b/src/components/CustomFormFields/Dateinputs/tests/CustomDateTime.test.js
@@ -354,26 +354,6 @@ describe('functions', () => {
         })
     })
 
-    describe('componentDidMount', () => {
-        test('sets focus to ref firstInput if prop.setInitialFocus is true', () => {
-            const wrapper = mount(<UnconnectedCustomDateTime {...defaultProps} setInitialFocus={true} />, {context: {intl}});
-            const instance = wrapper.instance()
-            const firstInput = instance.firstInput
-            jest.spyOn(firstInput.current, 'focus')
-            instance.componentDidMount()
-            expect(firstInput.current.focus).toHaveBeenCalledTimes(1)
-        })
-
-        test('doesnt set focus to firstInput if prop.setInitialFocus is not true', () => {
-            const wrapper = mount(<UnconnectedCustomDateTime {...defaultProps} setInitialFocus={false} />, {context: {intl}});
-            const instance = wrapper.instance()
-            const firstInput = instance.firstInput
-            jest.spyOn(firstInput.current, 'focus')
-            instance.componentDidMount()
-            expect(firstInput.current.focus).toHaveBeenCalledTimes(0)
-        })
-    })
-
     describe('componentDidUpdate', () => {
         const spy = jest.spyOn(UnconnectedCustomDateTime.prototype, 'validateDate');
 
@@ -382,7 +362,7 @@ describe('functions', () => {
         })
             
         test('calls validateDate if state.dateInputValue and state.timeInputValue are defined', () => {
-            const wrapper = mount(<UnconnectedCustomDateTime {...defaultProps} />, {context: {intl}});
+            const wrapper = shallow(<UnconnectedCustomDateTime {...defaultProps} />, {context: {intl}});
             const instance = wrapper.instance()
             instance.state.dateInputValue = '123'
             instance.state.timeInputValue = '456'
@@ -396,7 +376,7 @@ describe('functions', () => {
         })
 
         test('doesnt call validateDate if state.dateInputValue and state.timeInputValue are not defined', () => {
-            const wrapper = mount(<UnconnectedCustomDateTime {...defaultProps} />, {context: {intl}});
+            const wrapper = shallow(<UnconnectedCustomDateTime {...defaultProps} />, {context: {intl}});
             const instance = wrapper.instance()
             instance.setState({dateInputValue: '', timeInputValue: ''})
             const minDate = moment('2020-03-23')

--- a/src/components/CustomFormFields/Dateinputs/tests/DatePickerButton.test.js
+++ b/src/components/CustomFormFields/Dateinputs/tests/DatePickerButton.test.js
@@ -4,7 +4,7 @@ import {shallow} from 'enzyme';
 import {IntlProvider} from 'react-intl';
 import mapValues from 'lodash/mapValues';
 import fiMessages from 'src/i18n/fi.json';
-import {Button} from 'reactstrap';
+import {Button, UncontrolledTooltip} from 'reactstrap';
 const testMessages = mapValues(fiMessages, (value, key) => value);
 const intlProvider = new IntlProvider({locale: 'fi', messages: testMessages}, {});
 const {intl} = intlProvider.getChildContext();
@@ -24,11 +24,18 @@ describe('DatePickerButton', () => {
         const wrapper = getWrapper()
         const button = wrapper.find(Button)
         expect(wrapper.find(Button)).toHaveLength(1)
+        expect(button.prop('id')).toBe(defaultProps.id)
         expect(button.prop('disabled')).toBe(defaultProps.disabled)
         expect(button.prop('aria-hidden')).toBe(true)
         expect(button.prop('aria-label')).toBe(intl.formatMessage({id: 'date-picker-button-label'}))
         expect(button.prop('tabIndex')).toBe(-1)
         expect(button.prop('onClick')).toBe(defaultProps.onClick)
         expect(button.prop('className')).toBe('custom-date-input__button glyphicon glyphicon-calendar')
+        const toolTip = wrapper.find(UncontrolledTooltip)
+        expect(wrapper.find(UncontrolledTooltip)).toHaveLength(1)
+        expect(toolTip.prop('placement')).toBe('top')
+        expect(toolTip.prop('target')).toBe(defaultProps.id)
+        expect(toolTip.prop('innerClassName')).toBe('tooltip-disabled')
+        expect(toolTip.prop('hideArrow')).toBeDefined
     })
 })

--- a/src/components/Header/LanguageSelector.test.js
+++ b/src/components/Header/LanguageSelector.test.js
@@ -4,6 +4,7 @@ import LanguageSelector from './LanguageSelector';
 import {IntlProvider} from 'react-intl';
 import fiMessages from 'src/i18n/fi.json';
 import mapValues from 'lodash/mapValues';
+
 const testMessages = mapValues(fiMessages, (value, key) => value);
 const intlProvider = new IntlProvider({locale: 'fi', messages: testMessages}, {});
 const {intl} = intlProvider.getChildContext();
@@ -25,8 +26,9 @@ const defaultProps = {
     userLocale: {
         locale: 'fi',
     },
-    changeLanguage : () => null,
+    changeLanguage: () => null,
 };
+
 describe('languageSelector', () => {
     function getWrapper(props) {
         return shallow(<LanguageSelector {...defaultProps} {...props} />, {context: {intl}});
@@ -37,12 +39,40 @@ describe('languageSelector', () => {
             expect(element).toHaveLength(2);
             const sec = element.at(1).find('a');
             expect(sec.text()).toBe('FI');
-        })
+        });
 
         test('activeLocale when en', () => {
-            const element = getWrapper({userLocale:{locale:'en'}}).find('div').at(1).find('a');
+            const element = getWrapper({userLocale: {locale: 'en'}})
+                .find('div')
+                .at(1)
+                .find('a');
             expect(element.text()).toBe('EN');
-        })
-    })
+        });
 
-})
+        test('activeLocale when sv', () => {
+            const element = getWrapper({userLocale: {locale: 'sv'}})
+                .find('div')
+                .at(1)
+                .find('a');
+            expect(element.text()).toBe('SV');
+        });
+    });
+    describe('Function tests', () => {
+        test('isOpen default state', () => {
+            const element = getWrapper();
+            expect(element.state('isOpen')).toBe(false);
+        });
+        test('<li> element gets correct props', () => {
+            const element = getWrapper().find('li');
+            expect(element).toHaveLength(3);
+            const first = element.at(1);
+            expect(first.prop('role')).toBe('presentation');
+            expect(first.prop('onClick')).toBeDefined();
+            expect(first.prop('className')).toBe('language-item');
+        });
+        test('onClick fires handleLanguageChange', () => {
+            const wrapper = getWrapper();
+            const instance = wrapper.instance();
+        });
+    });
+});

--- a/src/components/Header/LanguageSelector.test.js
+++ b/src/components/Header/LanguageSelector.test.js
@@ -72,8 +72,7 @@ describe('languageSelector', () => {
         });
         test('click calls changeLanguage', () => {
             const wrapper = getWrapper();
-            const instance = wrapper.instance();
-            const spy = jest.spyOn(instance.props,'changeLanguage');
+            const spy = jest.spyOn(wrapper.instance().props,'changeLanguage');
             const liElement = wrapper.find('li').at(0);
             
             liElement.simulate('click', {preventDefault: () => {}});

--- a/src/components/Header/LanguageSelector.test.js
+++ b/src/components/Header/LanguageSelector.test.js
@@ -26,7 +26,7 @@ const defaultProps = {
     userLocale: {
         locale: 'fi',
     },
-    changeLanguage: () => null,
+    changeLanguage: jest.fn(),
 };
 
 describe('languageSelector', () => {
@@ -70,9 +70,14 @@ describe('languageSelector', () => {
             expect(first.prop('onClick')).toBeDefined();
             expect(first.prop('className')).toBe('language-item');
         });
-        test('onClick fires handleLanguageChange', () => {
+        test('click calls changeLanguage', () => {
             const wrapper = getWrapper();
             const instance = wrapper.instance();
+            const spy = jest.spyOn(instance.props,'changeLanguage');
+            const liElement = wrapper.find('li').at(0);
+            
+            liElement.simulate('click', {preventDefault: () => {}});
+            expect(spy).toHaveBeenCalled();
         });
     });
 });

--- a/src/components/HelFormFields/HelKeywordSelector/HelKeywordSelector.js
+++ b/src/components/HelFormFields/HelKeywordSelector/HelKeywordSelector.js
@@ -1,14 +1,15 @@
-import {HelLabeledCheckboxGroup, HelSelect} from '../index'
-import {FormattedMessage} from 'react-intl'
-import SelectedKeywords from '../../SelectedKeywords/SelectedKeywords'
 import React, {useEffect, useState} from 'react'
-import {SideField} from '../../FormFields'
+import PropTypes from 'prop-types'
 import {get, isNil, uniqBy} from 'lodash'
+import {connect} from 'react-redux'
+import {FormattedMessage} from 'react-intl'
+import {HelLabeledCheckboxGroup, HelSelect} from '../index'
+import SelectedKeywords from '../../SelectedKeywords/SelectedKeywords'
+import {SideField} from '../../FormFields'
 import {mapKeywordSetToForm} from '../../../utils/apiDataMapping'
 import {setData as setDataAction} from '../../../actions/editor'
-import PropTypes from 'prop-types'
-import {connect} from 'react-redux'
 import {CopyToClipboard} from 'react-copy-to-clipboard'
+import {UncontrolledTooltip} from 'reactstrap'
 
 const handleKeywordChange = (checkedOptions, keywords, mainCategoryOptions, setData) => {
     if (isNil(checkedOptions)) {
@@ -125,11 +126,11 @@ const HelKeywordSelector = ({intl, editor, setDirtyState, setData, currentLocale
                     currentLocale={currentLocale}
                 />
                 <CopyToClipboard tabIndex='-1' aria-hidden='true' text={values['keywords'] ? getKeywordIds(keywords) : ''}>
-                    <button type='button' className="clipboard-copy-button btn btn-default" aria-label={intl.formatMessage({id: 'copy-keyword-to-clipboard'})}>
+                    <button id='keyword-clipboard' type='button' className="clipboard-copy-button btn btn-default" aria-label={intl.formatMessage({id: 'copy-keyword-to-clipboard'})}>
                         <span className="glyphicon glyphicon-duplicate" aria-hidden="true"></span>
-                        <p hidden>duplicate</p>
                     </button>
                 </CopyToClipboard>
+                <UncontrolledTooltip placement='top' target='keyword-clipboard' hideArrow>{intl.formatMessage({id: 'copy-keyword-to-clipboard'})}</UncontrolledTooltip>
                 <SelectedKeywords
                     selectedKeywords={keywords}
                     onDelete={(deletedItem) => handleKeywordDelete(deletedItem, keywords, setData)}


### PR DESCRIPTION
Added tooltips for Calendar components and Copy keyword to clipboard button.

Removed some old tests which were causing errors because of these changes.
More specifically, Input focus checks with mounting isn't probably necessary.