### PR TITLE
Added focus effect to skip-link

### DIFF
--- a/src/components/SkipLink/index.js
+++ b/src/components/SkipLink/index.js
@@ -19,7 +19,9 @@ class SkipLink extends React.Component {
         );
     }
 }
+
 SkipLink.contextTypes = {
     intl: PropTypes.object,
-}
+};
+
 export default SkipLink;

--- a/src/components/SkipLink/index.scss
+++ b/src/components/SkipLink/index.scss
@@ -1,24 +1,14 @@
-.skiplink-shortcut{
+.skiplink-shortcut {
     text-align: center;
-    background-color:white;
+    background-color: white;
     .visually-hidden {
-        position: absolute;
-        left: -10000px;
-        top: auto;
-        width: 1px;
-        height: 1px;
-        overflow: hidden;
-      &.skip-link {
-        &:focus,
-        &:active {
-          position: relative;
-          left: 0;
-          width: auto;
-          height: auto;
-          overflow: visible;
-          outline: none;
-          color:blue;
+        &.skip-link {
+            &:focus,
+            &:active {
+                position: relative;
+                left: 0;
+                color: blue;
+            }
         }
-      }
     }
-  }
+}


### PR DESCRIPTION
Did some additional testing and looked at Global Accessibility (WC3) specifications.
I was unable find any specific mentions on how skip-link is supposed to act/work on mobile (other than having some sort of focus indication).
So for now I think this implementation is fine.