### PR TITLE
Image radio inputs and hide/show events

### DIFF
--- a/src/components/FormFields/FormFields.test.js
+++ b/src/components/FormFields/FormFields.test.js
@@ -116,7 +116,7 @@ describe('FormField', () => {
                 test('amount of formattedmessages', () => {
                     const wrapper = getWrapper()
                     const messages = wrapper.find(FormattedMessage)
-                    expect(messages).toHaveLength(36)
+                    expect(messages).toHaveLength(37)
                 })
             })
             describe('SideField', () => {

--- a/src/components/FormFields/index.js
+++ b/src/components/FormFields/index.js
@@ -15,7 +15,7 @@ import {
     HelKeywordSelector,
 } from 'src/components/HelFormFields'
 import RecurringEvent from 'src/components/RecurringEvent'
-import {Button,Form, FormGroup, Collapse} from 'reactstrap';
+import {Button, Form, FormGroup, Collapse, UncontrolledCollapse} from 'reactstrap';
 import {mapKeywordSetToForm, mapLanguagesSetToForm} from '../../utils/apiDataMapping'
 import {setEventData, setData} from '../../actions/editor'
 import {get, isNull, pickBy} from 'lodash'
@@ -81,6 +81,7 @@ class FormFields extends React.Component {
             headerCourses: false,
             headerDescription: false,
             headerImage: false,
+            displayEvents: true,
         }
         
         this.handleOrganizationChange = this.handleOrganizationChange.bind(this)
@@ -126,6 +127,11 @@ class FormFields extends React.Component {
 
     showRecurringEventDialog() {
         this.setState({showRecurringEvent: !this.state.showRecurringEvent})
+    }
+
+    // Replace with more proper functionality - preferably something that will hide the button if event length == 0.
+    showEventList() {
+        this.setState({displayEvents: !this.state.displayEvents})
     }
 
     showNewEventDialog() {
@@ -448,8 +454,20 @@ class FormFields extends React.Component {
                             </div>
                         </div>
                         <div className={'new-events ' + (this.state.showNewEvents ? 'show' : 'hidden')}>
-                            { newEvents }
+                            <UncontrolledCollapse toggler='#events-list' defaultOpen>
+                                { newEvents }
+                            </UncontrolledCollapse>
                         </div>
+                        <Button 
+                            block 
+                            className='btn'
+                            id='events-list'
+                            onClick={() => this.showEventList()}>
+                            {this.state.displayEvents
+                                ? <FormattedMessage id='event-list-hide'/>
+                                : <FormattedMessage id='event-list-show'/>
+                            }
+                        </Button>
                         {this.state.showRecurringEvent &&
                             <RecurringEvent
                                 toggle={() => this.showRecurringEventDialog()}

--- a/src/components/ImageEdit/index.js
+++ b/src/components/ImageEdit/index.js
@@ -341,7 +341,6 @@ class ImageEdit extends React.Component {
     }
 
     getLicense() {
-        const temp = (string) => this.props.updateExisting && this.state.license === string ? 'checked' : null;
         return (
             <div className='image-license-container'>
                 <div className='license-choices'>
@@ -365,7 +364,7 @@ class ImageEdit extends React.Component {
                             name='license_type'
                             value='event_only'
                             onChange={this.handleLicenseChange}
-                            checked={temp('event_only')} 
+                            checked
                         />
                         <label className='custom-control-label' htmlFor='event_only'>
                             <FormattedMessage id={'image-modal-license-restricted-to-event'}/>
@@ -379,7 +378,6 @@ class ImageEdit extends React.Component {
                             name='license_type'
                             value='cc_by'
                             onChange={this.handleLicenseChange}
-                            checked={temp('cc_by')} 
                         />
                         <label className='custom-control-label' htmlFor='cc_by'>
                             Creative Commons BY 4.0

--- a/src/components/ImagePicker/__snapshots__/ImagePicker.test.js.snap
+++ b/src/components/ImagePicker/__snapshots__/ImagePicker.test.js.snap
@@ -177,6 +177,8 @@ exports[`Image add form ImagePicker component should render correctly with data 
       "event-isvirtual": "Tämä tapahtuma on virtuaalinen",
       "event-keywords": "Lisää asiasanoja",
       "event-keywords-delete": "Poista asiasana",
+      "event-list-hide": "Piilota tapahtumat",
+      "event-list-show": "Näytä tapahtumat",
       "event-location": "Paikka",
       "event-location-additional-info": "Paikan lisätiedot",
       "event-location-button": "Näytä kartalla",

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -475,5 +475,8 @@
 
     "login-warning": "Warning! You must",
     "login-warning1": "login",
-    "login-warning2": "to be able to submit or edit events!"
+    "login-warning2": "to be able to submit or edit events!",
+
+    "event-list-show": "Show events",
+    "event-list-hide": "Hide events"
 }

--- a/src/i18n/fi.json
+++ b/src/i18n/fi.json
@@ -516,5 +516,8 @@
 
     "login-warning": "Huom! Sinun täytyy",
     "login-warning1": "kirjautua sisään",
-    "login-warning2": "lisätäksesi tapahtuman!"
+    "login-warning2": "lisätäksesi tapahtuman!",
+
+    "event-list-show": "Näytä tapahtumat",
+    "event-list-hide": "Piilota tapahtumat"
 }

--- a/src/i18n/sv.json
+++ b/src/i18n/sv.json
@@ -453,5 +453,8 @@
     "close-preview-modal": "Stäng förhandsvisning",
     "close-image-gallery-modal": "Stäng bildgalleridialogen",
     "close-image-edit-modal": "Stäng dialogrutan Lägg till / redigera bild",
-    "profile-menu": " Profilmeny"
+    "profile-menu": " Profilmeny",
+
+    "event-list-show": "Visa händelser",
+    "event-list-hide": "Dölj händelser"
 }

--- a/src/views/EventListing/__snapshots__/EventListing.test.js.snap
+++ b/src/views/EventListing/__snapshots__/EventListing.test.js.snap
@@ -384,6 +384,8 @@ exports[`EventListing Snapshot should render view correctly 1`] = `
       "event-isvirtual": "Tämä tapahtuma on virtuaalinen",
       "event-keywords": "Lisää asiasanoja",
       "event-keywords-delete": "Poista asiasana",
+      "event-list-hide": "Piilota tapahtumat",
+      "event-list-show": "Näytä tapahtumat",
       "event-location": "Paikka",
       "event-location-additional-info": "Paikan lisätiedot",
       "event-location-button": "Näytä kartalla",

--- a/src/views/Search/__snapshots__/Search.test.js.snap
+++ b/src/views/Search/__snapshots__/Search.test.js.snap
@@ -177,6 +177,8 @@ exports[`Search Snapshot should render view correctly 1`] = `
       "event-isvirtual": "Tämä tapahtuma on virtuaalinen",
       "event-keywords": "Lisää asiasanoja",
       "event-keywords-delete": "Poista asiasana",
+      "event-list-hide": "Piilota tapahtumat",
+      "event-list-show": "Näytä tapahtumat",
       "event-location": "Paikka",
       "event-location-additional-info": "Paikan lisätiedot",
       "event-location-button": "Näytä kartalla",


### PR DESCRIPTION
Fixed Add Image modal radio inputs to have 'event_only' checked by default.

Added hide/show events button to form in case users want to hide a long chain of events.

This implementation is temporary and is meant to be improved upon with the upcoming RecurringEvent fixes.