### PR TITLE
Changed event page to fetch data when user changes

### DIFF
--- a/src/views/Event/Event.test.js
+++ b/src/views/Event/Event.test.js
@@ -24,4 +24,31 @@ describe('EventPage', () => {
         const pageTitle = wrapper.prop('title');
         expect(pageTitle).toBe('Linkedevents - ');
     });
+
+    describe('functions', () => {
+        describe('componentDidUpdate', () => {
+            const wrapper = getWrapper()
+            const instance = wrapper.instance()
+            const fetchDataSpy = jest.spyOn(instance, 'fetchEventData')
+
+            afterEach(() => { fetchDataSpy.mockClear() })
+            afterAll(() => { fetchDataSpy.mockRestore() })
+
+            test('fetchEventData is called when user prop changes', () => {
+                wrapper.setProps({user: {id: '123abc'}})
+                wrapper.setProps({user: {id: '567fgh'}})
+                wrapper.setProps({user: null})
+                expect(fetchDataSpy).toHaveBeenCalledTimes(3)
+            })
+
+            test('fetchEventData is not called when user prop does not change', () => {
+                const user = {user: {id: '123abc'}}
+                wrapper.setProps({user})
+                expect(fetchDataSpy).toHaveBeenCalledTimes(1)
+                fetchDataSpy.mockClear()
+                wrapper.setProps({user})
+                expect(fetchDataSpy).toHaveBeenCalledTimes(0)
+            })
+        })
+    })
 });

--- a/src/views/Event/index.js
+++ b/src/views/Event/index.js
@@ -58,6 +58,11 @@ class EventPage extends React.Component {
             this.fetchEventData()
         }
 
+        // refresh event data when user changes to handle data behind permissions
+        if (prevProps.user !== this.props.user){
+            this.fetchEventData()
+        }
+
         if (publisherId && publisherId !== oldPublisherId) {
             client.get(`organization/${publisherId}`)
                 .then(response => this.setState({publisher: response.data}))


### PR DESCRIPTION
This change fixes potential issues where data behind user permissions is not shown after page refresh