### PR TITLE
Reworked LanguageSelect disabled attribute

### DIFF
--- a/src/components/HelFormFields/HelCheckbox.scss
+++ b/src/components/HelFormFields/HelCheckbox.scss
@@ -1,3 +1,11 @@
 .price-label {
     margin-top: 0.5rem;
 }
+.language-selection {
+    .custom-control.custom-checkbox .custom-control-input:checked ~ .custom-control-label.disabled::before {
+        background-color: rgba(0, 98, 174, 0.6);
+    }
+    .custom-checkbox .custom-control-input:checked ~ .custom-control-label.disabled::after {
+        cursor: not-allowed;
+    }
+}

--- a/src/components/HelFormFields/HelLanguageSelect.js
+++ b/src/components/HelFormFields/HelLanguageSelect.js
@@ -4,15 +4,31 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import {FormattedMessage} from 'react-intl';
 import {connect} from 'react-redux';
+import classNames from 'classnames';
 import {setLanguages as setLanguageAction} from 'src/actions/editor.js';
 
 class HelLanguageSelect extends React.Component {
+    constructor(props) {
+        super(props);
+        this.state = {
+            lang: this.props.checked,
+        }
+    }
+
+    componentDidUpdate(prevProps) {
+        if (prevProps.checked !== this.props.checked) {
+            this.setState({lang: this.props.checked})
+        }
+    }
+
     onChange = () => {
         const {options} = this.props;
         const checkedOptions = options
             .filter((option, index) => this[`checkRef${index}`].checked)
             .map((checkedOption) => checkedOption.value);
-
+        if (checkedOptions.length === 0 && this.state.lang.length !== 0) {
+            return null
+        }
         this.props.setLanguages(checkedOptions);
 
         if (typeof this.props.onChange === 'function') {
@@ -37,11 +53,11 @@ class HelLanguageSelect extends React.Component {
                         key={index}
                         name={item.value}
                         checked={isChecked}
-                        disabled={disabled}
                         onChange={this.onChange}
                         aria-checked={isChecked}
+                        aria-disabled={disabled}
                     />
-                    <label className='custom-control-label' htmlFor={`checkBox-${item.value}`}>
+                    <label className={classNames('custom-control-label', {disabled: disabled})} htmlFor={`checkBox-${item.value}`}>
                         <FormattedMessage id={item.label} />
                     </label>
                 </div>
@@ -65,4 +81,5 @@ const mapDispatchToProps = (dispatch) => ({
 
 const mapStateToProps = () => ({});
 // TODO: if leave null, react-intl not refresh. Replace this with better React context
+export {HelLanguageSelect as UnconnectedLanguageSelect}
 export default connect(mapStateToProps, mapDispatchToProps)(HelLanguageSelect);

--- a/src/components/HelFormFields/tests/HelLanguageSelect.test.js
+++ b/src/components/HelFormFields/tests/HelLanguageSelect.test.js
@@ -1,27 +1,27 @@
 import React from 'react';
 import {shallow} from 'enzyme';
-import {UnconnectedLanguageSelect} from '../HelLanguageSelect';
 import {FormattedMessage} from 'react-intl';
-import {setLanguages as setLanguageAction} from 'src/actions/editor.js';
-jest.mock('../../../actions/editor');
+import {UnconnectedLanguageSelect} from '../HelLanguageSelect';
 
 const defaultProps = {
-    setLanguages: () => {},
-    onChange: () => {},
     options: [
         {value: 'fi', label: 'FI'},
         {value: 'sv', label: 'SV'},
         {value: 'en', label: 'EN'},
     ],
+    onChange: () => {},
+    setLanguages: () => {},
     checked: ['fi'],
 };
 
-describe('Language Select', () => {
+describe('HelLanguageSelect', () => {
     function getWrapper(props) {
-        return shallow(<UnconnectedLanguageSelect {...props} {...defaultProps} />);
+        return shallow(<UnconnectedLanguageSelect {...defaultProps} {...props} />);
     }
 
     describe('renderer', () => {
+        const availableLanguages = ['fi', 'sv', 'en'];
+
         test('number of divs', () => {
             const div = getWrapper().find('div');
             expect(div).toHaveLength(4);
@@ -30,36 +30,44 @@ describe('Language Select', () => {
         });
         describe('input checkbox', () => {
             test('LanguageSelect input checkbox gets correct props', () => {
-                const checkbox = getWrapper().find('input');
-                expect(checkbox).toHaveLength(3);
-                expect(checkbox.at(0).prop('className')).toBe('custom-control-input');
-                expect(checkbox.at(0).prop('type')).toBe('checkbox');
-                expect(checkbox.at(0).prop('id')).toBe('checkBox-fi');
-                expect(checkbox.at(1).prop('id')).toBe('checkBox-sv');
-                expect(checkbox.at(2).prop('id')).toBe('checkBox-en');
-                expect(checkbox.at(0).prop('aria-checked')).toBe(true);
-                expect(checkbox.at(1).prop('aria-checked')).toBe(false);
-                expect(checkbox.at(2).prop('aria-checked')).toBe(false);
-                expect(checkbox.at(0).prop('aria-disabled')).toBe(true);
-                expect(checkbox.at(1).prop('aria-disabled')).toBe(false);
-                expect(checkbox.at(2).prop('aria-disabled')).toBe(false);
+                const activeLang = availableLanguages[Math.floor(Math.random() * availableLanguages.length)];
+                const checkboxes = getWrapper({checked: [activeLang]}).find('input');
+
+                expect(checkboxes).toHaveLength(3);
+                checkboxes.forEach((checkbox, index) => {
+                    expect(checkbox.prop('className')).toBe('custom-control-input');
+                    expect(checkbox.prop('type')).toBe('checkbox');
+                    expect(checkbox.prop('id')).toBe(`checkBox-${availableLanguages[index]}`);
+                    if (availableLanguages[index] === activeLang) {
+                        expect(checkbox.prop('aria-checked')).toBe(true);
+                        expect(checkbox.prop('aria-disabled')).toBe(true);
+                    } else {
+                        expect(checkbox.prop('aria-checked')).toBe(false);
+                        expect(checkbox.prop('aria-disabled')).toBe(false);
+                    }
+                });
             });
         });
         describe('label and FormattedMessage', () => {
             test('label gets correct props', () => {
-                const label = getWrapper().find('label');
-                expect(label).toHaveLength(3);
-                expect(label.at(0).prop('className')).toBe('custom-control-label disabled');
-                expect(label.at(0).prop('htmlFor')).toBe('checkBox-fi');
-                expect(label.at(1).prop('htmlFor')).toBe('checkBox-sv');
-                expect(label.at(2).prop('htmlFor')).toBe('checkBox-en');
+                const activeLang = availableLanguages[Math.floor(Math.random() * availableLanguages.length)];
+                const labels = getWrapper({checked: [activeLang]}).find('label');
+                expect(labels).toHaveLength(3);
+                labels.forEach((label, index) => {
+                    expect(label.prop('htmlFor')).toBe(`checkBox-${availableLanguages[index]}`);
+                    if (availableLanguages[index] === activeLang) {
+                        expect(label.prop('className')).toBe('custom-control-label disabled');
+                    } else {
+                        expect(label.prop('className')).toBe('custom-control-label');
+                    }
+                });
             });
             test('renders a FormattedMessage', () => {
-                const message = getWrapper().find(FormattedMessage);
-                expect(message).toHaveLength(3);
-                expect(message.at(0).prop('id')).toBe('FI');
-                expect(message.at(1).prop('id')).toBe('SV');
-                expect(message.at(2).prop('id')).toBe('EN');
+                const messages = getWrapper().find(FormattedMessage);
+                expect(messages).toHaveLength(3);
+                messages.forEach((message, index) => {
+                    expect(message.prop('id')).toBe(availableLanguages[index].toUpperCase());
+                });
             });
         });
     });

--- a/src/components/HelFormFields/tests/HelLanguageSelect.test.js
+++ b/src/components/HelFormFields/tests/HelLanguageSelect.test.js
@@ -1,0 +1,66 @@
+import React from 'react';
+import {shallow} from 'enzyme';
+import {UnconnectedLanguageSelect} from '../HelLanguageSelect';
+import {FormattedMessage} from 'react-intl';
+import {setLanguages as setLanguageAction} from 'src/actions/editor.js';
+jest.mock('../../../actions/editor');
+
+const defaultProps = {
+    setLanguages: () => {},
+    onChange: () => {},
+    options: [
+        {value: 'fi', label: 'FI'},
+        {value: 'sv', label: 'SV'},
+        {value: 'en', label: 'EN'},
+    ],
+    checked: ['fi'],
+};
+
+describe('Language Select', () => {
+    function getWrapper(props) {
+        return shallow(<UnconnectedLanguageSelect {...props} {...defaultProps} />);
+    }
+
+    describe('renderer', () => {
+        test('number of divs', () => {
+            const div = getWrapper().find('div');
+            expect(div).toHaveLength(4);
+            expect(div.at(0).prop('className')).toBe('language-selection');
+            expect(div.at(1).prop('className')).toBe('custom-control custom-checkbox');
+        });
+        describe('input checkbox', () => {
+            test('LanguageSelect input checkbox gets correct props', () => {
+                const checkbox = getWrapper().find('input');
+                expect(checkbox).toHaveLength(3);
+                expect(checkbox.at(0).prop('className')).toBe('custom-control-input');
+                expect(checkbox.at(0).prop('type')).toBe('checkbox');
+                expect(checkbox.at(0).prop('id')).toBe('checkBox-fi');
+                expect(checkbox.at(1).prop('id')).toBe('checkBox-sv');
+                expect(checkbox.at(2).prop('id')).toBe('checkBox-en');
+                expect(checkbox.at(0).prop('aria-checked')).toBe(true);
+                expect(checkbox.at(1).prop('aria-checked')).toBe(false);
+                expect(checkbox.at(2).prop('aria-checked')).toBe(false);
+                expect(checkbox.at(0).prop('aria-disabled')).toBe(true);
+                expect(checkbox.at(1).prop('aria-disabled')).toBe(false);
+                expect(checkbox.at(2).prop('aria-disabled')).toBe(false);
+            });
+        });
+        describe('label and FormattedMessage', () => {
+            test('label gets correct props', () => {
+                const label = getWrapper().find('label');
+                expect(label).toHaveLength(3);
+                expect(label.at(0).prop('className')).toBe('custom-control-label disabled');
+                expect(label.at(0).prop('htmlFor')).toBe('checkBox-fi');
+                expect(label.at(1).prop('htmlFor')).toBe('checkBox-sv');
+                expect(label.at(2).prop('htmlFor')).toBe('checkBox-en');
+            });
+            test('renders a FormattedMessage', () => {
+                const message = getWrapper().find(FormattedMessage);
+                expect(message).toHaveLength(3);
+                expect(message.at(0).prop('id')).toBe('FI');
+                expect(message.at(1).prop('id')).toBe('SV');
+                expect(message.at(2).prop('id')).toBe('EN');
+            });
+        });
+    });
+});


### PR DESCRIPTION
Removed old disabled prop in favour of aria-disabled. Now you can still access language selection with tab even if the checkbox is disabled.
Adjusted styles to fit these changes and wrote some tests with @hienous