### PR TITLE
Changed min price to be 0

### DIFF
--- a/src/components/HelFormFields/NewOffer.js
+++ b/src/components/HelFormFields/NewOffer.js
@@ -92,7 +92,7 @@ class NewOffer extends React.Component {
                 <MultiLanguageField
                     id={'event-price' + this.props.offerKey}
                     type='number'
-                    min={1}
+                    min={0}
                     defaultValue={defaultValue.price} 
                     disabled={isFree} 
                     ref="price" 


### PR DESCRIPTION
During our meeting we talked about the fact that some events might have free entry for certain age groups, like elderly or children.

So it would only make sense to have the option to set the event price to 0 if needed.