### PR TITLE
Updated imageEdit.js

### DIFF
--- a/src/components/ImageEdit/ImageEdit.test.js
+++ b/src/components/ImageEdit/ImageEdit.test.js
@@ -236,6 +236,36 @@ describe('ImageEdit', () => {
                     expect(close).toHaveBeenCalled();
 
                 });
+                test('calls postImage with correct alt_text when hideAltText-state is true', async () => {
+                    const wrapper = getWrapper({postImage, close, imageFile});
+                    wrapper.setState({imageFile: imageFile});
+                    const checked = (bool) => ({target: {checked: bool}});
+                    jest.spyOn(wrapper.instance(),'imageToBase64');
+                    wrapper.instance().handleChange({target:{id:'altText'}}, {fi:'finnishAlt'});
+                    wrapper.instance().handleChange({target:{id:'name'}}, {fi:'finnishName'});
+                    wrapper.instance().handleChange({target:{id:'photographerName'}}, 'Photographer Phil');
+                    wrapper.instance().setAltDecoration(checked(true))
+                    const expectedImage = await wrapper.instance().imageToBase64(defaultImageBlob);
+                    await wrapper.instance().handleImagePost();
+
+                    const imageToPost = {
+                        alt_text: {
+                            fi: 'Kuva on koriste',
+                        },
+                        name: {
+                            fi: 'finnishName',
+                        },
+                        file_name: 'testfile',
+                        image: expectedImage,
+                        license: 'event_only',
+                        photographer_name: 'Photographer Phil',
+                    };
+
+                    expect(wrapper.instance().imageToBase64).toHaveBeenCalled();
+                    expect(postImage).toHaveBeenCalledWith(imageToPost,defaultUser,null)
+                    expect(close).toHaveBeenCalled();
+
+                });
             });
         });
 
@@ -440,11 +470,6 @@ describe('ImageEdit', () => {
                 expect(wrapper.state('hideAltText')).toBe(false);
                 instance.setAltDecoration(checked(true));
                 expect(wrapper.state('hideAltText')).toBe(true);
-            })
-            test('calling setAltDecoration with altText to set input-value', () => {
-                instance.setAltDecoration({target:{id:'altText'}},{fi: 'Kuva on koriste'});
-                const element = wrapper.find(MultiLanguageField).at(0);
-                expect(element.prop('defaultValue')).toEqual({fi: 'Kuva on koriste'});
             })
         })
 

--- a/src/components/ImageEdit/index.js
+++ b/src/components/ImageEdit/index.js
@@ -192,8 +192,10 @@ class ImageEdit extends React.Component {
      */
     async handleImagePost() {
         const langs = this.props.editor.contentLanguages;
-        const decorationAlts = {};
-        langs.forEach((lang)=> decorationAlts[lang] = this.context.intl.formatMessage({id: `description-alt.${lang}`}));
+        const decorationAlts = langs.reduce((acc,curr)  => {
+            acc[curr] = this.context.intl.formatMessage({id: `description-alt.${curr}`});
+            return acc;
+        },  {});
         let imageToPost = {
             name: this.state.image['name'],
             alt_text: this.state.image['altText'],

--- a/src/components/ImageEdit/index.js
+++ b/src/components/ImageEdit/index.js
@@ -192,8 +192,8 @@ class ImageEdit extends React.Component {
      */
     async handleImagePost() {
         const langs = this.props.editor.contentLanguages;
-        const DecorationAlts = {};
-        langs.forEach((lang)=> DecorationAlts[lang] = this.context.intl.formatMessage({id: `description-alt.${lang}`}));
+        const decorationAlts = {};
+        langs.forEach((lang)=> decorationAlts[lang] = this.context.intl.formatMessage({id: `description-alt.${lang}`}));
         let imageToPost = {
             name: this.state.image['name'],
             alt_text: this.state.image['altText'],
@@ -202,7 +202,7 @@ class ImageEdit extends React.Component {
         };
         if (this.state.hideAltText) {
             imageToPost = update(imageToPost, {
-                alt_text:{$set: DecorationAlts},
+                alt_text:{$set: decorationAlts},
             });
         }
         if (!this.props.updateExisting) {

--- a/src/components/ImageEdit/index.js
+++ b/src/components/ImageEdit/index.js
@@ -149,15 +149,7 @@ class ImageEdit extends React.Component {
      * @param e 
      */
     setAltDecoration(e) {
-        const decoration = e.target.checked
-        const langs = this.props.editor.contentLanguages;
-        const DecorationAlts = {};
-        langs.forEach((lang)=> DecorationAlts[lang] = this.context.intl.formatMessage({id: `description-alt.${lang}`}));
-        this.handleChange({target: {id: 'altText'}},
-            DecorationAlts)
-        this.setState({
-            hideAltText: decoration,
-        })
+        this.setState({hideAltText: e.target.checked})
     }
 
     /**
@@ -199,12 +191,20 @@ class ImageEdit extends React.Component {
      * @returns {Promise<void>}
      */
     async handleImagePost() {
+        const langs = this.props.editor.contentLanguages;
+        const DecorationAlts = {};
+        langs.forEach((lang)=> DecorationAlts[lang] = this.context.intl.formatMessage({id: `description-alt.${lang}`}));
         let imageToPost = {
             name: this.state.image['name'],
             alt_text: this.state.image['altText'],
             photographer_name: this.state.image['photographerName'],
             license: this.state.license,
         };
+        if (this.state.hideAltText) {
+            imageToPost = update(imageToPost, {
+                alt_text:{$set: DecorationAlts},
+            });
+        }
         if (!this.props.updateExisting) {
             if (this.props.imageFile || this.state.imageFile) {
                 let image64 = await this.imageToBase64(this.state.imageFile);
@@ -429,8 +429,8 @@ class ImageEdit extends React.Component {
                         <FormattedMessage id={'image-modal-image-info'}/>
                     </ModalHeader>
                     <ModalBody>
-                        <div className='row'>
-                            <div className='col-sm-8 image-edit-dialog--form'>
+                        <div>
+                            <div className='col-sm-12  image-edit-dialog--form'>
                                 {!this.props.updateExisting &&
                                 <div className='file-upload'>
                                     <div className='tip' aria-label={this.context.intl.formatMessage({id: 'image-upload-help'})}>
@@ -489,6 +489,9 @@ class ImageEdit extends React.Component {
                                                 >
                                                     <FormattedMessage id='upload-image-from-url-button' />
                                                 </Button>
+                                                <div className='image'>
+                                                    <img className="col-sm-6 image-edit-dialog--image" src={thumb} alt={getStringWithLocale(this.state.image,'altText')} />
+                                                </div>
                                                 <div className='tools'>
                                                     <Button
                                                         onClick={this.clearPictures}
@@ -533,7 +536,6 @@ class ImageEdit extends React.Component {
                                     <FormattedHTMLMessage id={'image-modal-view-terms-paragraph-text'}/>
                                 </div>
                             </div>
-                            <img className="col-sm-4 image-edit-dialog--image" src={thumb} alt={getStringWithLocale(this.state.image,'altText')} />
                             <div className="col-sm-12">
                                 <Button
                                     size="lg" block

--- a/src/components/ImageEdit/index.scss
+++ b/src/components/ImageEdit/index.scss
@@ -49,6 +49,14 @@
 					}
 					.file-upload--external {
 						#upload-external {
+							.image {
+								text-align: center;
+							.image-edit-dialog--image {
+								object-fit: contain;
+								max-width: 500px;
+								max-height: 500px;
+							}
+						}
 							input {
 								border-width: 2px;
 								border-style: solid;
@@ -92,9 +100,7 @@
 	.help-notice {
 		margin-top: 10px;
 	}
-	.image-edit-dialog--image {
-		object-fit: contain;
-	}
+
 	.btn-primary.disabled:hover {
 		background-color: #6c757d;
 	}


### PR DESCRIPTION
# Update to ImageEdits logic. [LIN207](https://trello.com/c/OPblN1Ke/207-ux-muuta-kuva-preview-paikka) & [LIN199](https://trello.com/c/xGB9rMC0/199-ux-alt-kent%C3%A4n-k%C3%A4ytett%C3%A4vyys)

## Changed how decoration to alt_text works & where picture is located during adding it to event.

### Includes update to tests, imageEdits logic & positioning of picture

-----------------------------------------------------------------------------------------------
### Breakdown:

#### ImageEdit
1. src/components/ImageEdit/index.js 
   * Scrapped logic of **"setAltDecoration"** -function. Now only toggles **"hideAltText"** state.
   * Updated logic of **"handleImagePost"** -function. if state **"hideAltText"** is true, adds decoration placeholders to images alt_text-value.
   * Changed pictures location. Preview of picture is now middle of form instead of the side.
   
#### ImageEdit styling
1. src/components/ImageEdit/index.scss
   * Changed styling
   
#### ImageEdit tests
1. src/components/ImageEdit/ImageEdit.test.js 
   * Removed test "calling setAltDecoration with altText to set input-value" & added new one with "calls postImage with correct alt_text when hideAltText-state is true" as we changed logic of decoration text.