### PR TITLE
Added validation to end_time & in sub_events for end_time

### DIFF
--- a/src/components/CustomFormFields/Dateinputs/CustomDateTime.js
+++ b/src/components/CustomFormFields/Dateinputs/CustomDateTime.js
@@ -130,12 +130,6 @@ class CustomDateTime extends React.Component {
                 this.validateDate(moment(datetimeString, getDateFormat('date-time'), true), minDate)
             }
         }
-        if (prevProps.defaultValue !== this.props.defaultValue) {
-            this.setState({
-                dateInputValue: this.props.defaultValue ? convertDateToLocaleString(this.props.defaultValue, 'date') : '',
-                timeInputValue: this.props.defaultValue ? convertDateToLocaleString(this.props.defaultValue, 'time') : '',
-            })
-        }
     }
 
 
@@ -175,7 +169,7 @@ class CustomDateTime extends React.Component {
                                 <Input
                                     aria-describedby={showValidationError ? inputErrorId : undefined}
                                     aria-invalid={showValidationError}
-                                    invalid={Array.isArray(validationErrors)}
+                                    invalid={dateInputValue ? false : Array.isArray(validationErrors)}
                                     type="text"
                                     name={name}
                                     id={dateFieldId}
@@ -192,7 +186,7 @@ class CustomDateTime extends React.Component {
                             </div>
                             <ValidationNotification
                                 anchor={this.containerRef}
-                                validationErrors={validationErrors}
+                                validationErrors={dateInputValue ? undefined : validationErrors}
                                 className='validation-dateTime' 
                             />
                         </div>
@@ -225,7 +219,7 @@ class CustomDateTime extends React.Component {
                                 <Input
                                     aria-describedby={showValidationError ? inputErrorId : undefined}
                                     aria-invalid={showValidationError}
-                                    invalid={Array.isArray(validationErrors)}
+                                    invalid={timeInputValue ? false : Array.isArray(validationErrors)}
                                     type="text"
                                     name={name}
                                     id={timeFieldId}
@@ -241,7 +235,7 @@ class CustomDateTime extends React.Component {
                             </div>
                             <ValidationNotification
                                 anchor={this.containerRef}
-                                validationErrors={validationErrors}
+                                validationErrors={timeInputValue ? undefined : validationErrors}
                                 className='validation-dateTime' 
                             />
                         </div>

--- a/src/components/CustomFormFields/Dateinputs/CustomDateTime.scss
+++ b/src/components/CustomFormFields/Dateinputs/CustomDateTime.scss
@@ -4,7 +4,7 @@
 
 .custom-date-time-input {
     .react-datepicker-popper {
-        z-index: 2;
+        z-index: 11;
     }
     justify-content: space-between;
     display: flex;

--- a/src/components/CustomFormFields/Dateinputs/tests/CustomDateTime.test.js
+++ b/src/components/CustomFormFields/Dateinputs/tests/CustomDateTime.test.js
@@ -219,7 +219,7 @@ describe('renders', () => {
                 expect(element.prop('invalid')).toBe(false)
             })
         })
-        test('invalid-prop is true in date when time has value & visa versa', () => {
+        test('invalid-prop is true in date when time has value & vice versa', () => {
             const wrapper = getWrapper({validationErrors: [VALIDATION_RULES.REQUIRED], defaultValue: ''});
             const instance = wrapper.instance();
             const timeInputValue = '01.02'
@@ -228,7 +228,7 @@ describe('renders', () => {
             expect(inputElement.at(0).prop('invalid')).toBe(true)
             expect(inputElement.at(1).prop('invalid')).toBe(false)
         })
-        test('invalid-prop is true in time when date has value & visa versa', () => {
+        test('invalid-prop is true in time when date has value & vice versa', () => {
             const wrapper = getWrapper({validationErrors: [VALIDATION_RULES.REQUIRED], defaultValue: ''});
             const instance = wrapper.instance();
             const dateInputValue = '02.01'

--- a/src/components/CustomFormFields/Dateinputs/tests/CustomDateTime.test.js
+++ b/src/components/CustomFormFields/Dateinputs/tests/CustomDateTime.test.js
@@ -206,7 +206,7 @@ describe('renders', () => {
         })
         test('invalid-prop is true when validationErrors exists', () => {
             const validation = [VALIDATION_RULES.REQUIRED]
-            const wrapper = getWrapper({validationErrors: validation});
+            const wrapper = getWrapper({validationErrors: validation, defaultValue: ''});
             const Inputs = wrapper.find(Input)
             Inputs.forEach((element, index) => {
                 expect(element.prop('invalid')).toBe(true)
@@ -218,6 +218,24 @@ describe('renders', () => {
             Inputs.forEach((element, index) => {
                 expect(element.prop('invalid')).toBe(false)
             })
+        })
+        test('invalid-prop is true in date when time has value & visa versa', () => {
+            const wrapper = getWrapper({validationErrors: [VALIDATION_RULES.REQUIRED], defaultValue: ''});
+            const instance = wrapper.instance();
+            const timeInputValue = '01.02'
+            instance.setState({timeInputValue})
+            const inputElement = wrapper.find(Input)
+            expect(inputElement.at(0).prop('invalid')).toBe(true)
+            expect(inputElement.at(1).prop('invalid')).toBe(false)
+        })
+        test('invalid-prop is true in time when date has value & visa versa', () => {
+            const wrapper = getWrapper({validationErrors: [VALIDATION_RULES.REQUIRED], defaultValue: ''});
+            const instance = wrapper.instance();
+            const dateInputValue = '02.01'
+            instance.setState({dateInputValue})
+            const inputElement = wrapper.find(Input)
+            expect(inputElement.at(0).prop('invalid')).toBe(false)
+            expect(inputElement.at(1).prop('invalid')).toBe(true)
         })
     })
     describe('ValidationNotification', () => {

--- a/src/validation/validator.js
+++ b/src/validation/validator.js
@@ -15,7 +15,7 @@ const draftValidations = {
     name: [VALIDATION_RULES.REQUIRE_MULTI, VALIDATION_RULES.REQUIRED_IN_CONTENT_LANGUAGE],
     location: [VALIDATION_RULES.REQUIRE_AT_ID],
     start_time: [VALIDATION_RULES.REQUIRED_STRING, VALIDATION_RULES.IS_DATE],
-    end_time: [VALIDATION_RULES.AFTER_START_TIME, VALIDATION_RULES.IN_THE_FUTURE],
+    end_time: [VALIDATION_RULES.REQUIRED_STRING, VALIDATION_RULES.AFTER_START_TIME, VALIDATION_RULES.IN_THE_FUTURE],
     price: [VALIDATION_RULES.HAS_PRICE],
     short_description: [VALIDATION_RULES.REQUIRE_MULTI, VALIDATION_RULES.REQUIRED_IN_CONTENT_LANGUAGE, VALIDATION_RULES.SHORT_STRING],
     description: [VALIDATION_RULES.LONG_STRING],
@@ -41,7 +41,7 @@ const publicValidations = {
     name: [VALIDATION_RULES.REQUIRE_MULTI, VALIDATION_RULES.REQUIRED_IN_CONTENT_LANGUAGE],
     location: [VALIDATION_RULES.REQUIRE_AT_ID],
     start_time: [VALIDATION_RULES.REQUIRED_STRING, VALIDATION_RULES.IS_DATE, VALIDATION_RULES.DEFAULT_END_IN_FUTURE], // Datetime is saved as ISO string
-    end_time: [VALIDATION_RULES.AFTER_START_TIME, VALIDATION_RULES.IS_DATE, VALIDATION_RULES.IN_THE_FUTURE],
+    end_time: [VALIDATION_RULES.REQUIRED_STRING, VALIDATION_RULES.AFTER_START_TIME, VALIDATION_RULES.IS_DATE, VALIDATION_RULES.IN_THE_FUTURE],
     price: [VALIDATION_RULES.HAS_PRICE],
     short_description: [VALIDATION_RULES.REQUIRE_MULTI, VALIDATION_RULES.REQUIRED_IN_CONTENT_LANGUAGE, VALIDATION_RULES.SHORT_STRING],
     description: [VALIDATION_RULES.LONG_STRING],
@@ -52,7 +52,7 @@ const publicValidations = {
     extlink_instagram: [VALIDATION_RULES.IS_URL],
     sub_events: { 
         start_time: [VALIDATION_RULES.REQUIRED_STRING, VALIDATION_RULES.IS_DATE, VALIDATION_RULES.DEFAULT_END_IN_FUTURE],
-        end_time: [VALIDATION_RULES.AFTER_START_TIME, VALIDATION_RULES.IS_DATE, VALIDATION_RULES.IN_THE_FUTURE],
+        end_time: [VALIDATION_RULES.REQUIRED_STRING, VALIDATION_RULES.AFTER_START_TIME, VALIDATION_RULES.IS_DATE, VALIDATION_RULES.IN_THE_FUTURE],
     },
     sub_length: [VALIDATION_RULES.IS_MORE_THAN_TWO, VALIDATION_RULES.IS_MORE_THAN_SIXTYFIVE],
     keywords: [VALIDATION_RULES.AT_LEAST_ONE_MAIN_CATEGORY],
@@ -120,8 +120,10 @@ function runValidationWithSettings(values, languages, settings, keywordSets) {
             errors = validateSubEventCount(values, validations)
             //Validate start_time
         } else if (key === 'start_time') {
-            errors = validateStartTime(values, validations)
-
+            errors = validateTimes(values, validations, 'start_time')
+            //Validate end_time
+        } else if (key === 'end_time') {
+            errors = validateTimes(values, validations, 'end_time')
         // check is_virtual boolean, is true check that virtualevent_url exists
         // validate virtual_url
         // Check for URL
@@ -194,16 +196,16 @@ const validateVirtualURL = (values, validations) => {
     }
     return errors
 }
-//Validate start_time
+//Validate start_time &/ end_time
 //Check if sub_events exist
-const validateStartTime = (values, validations) => {
+const validateTimes = (values, validations, type = '') => {
     const errors = []
     const isSingleMain = !values.hasOwnProperty('sub_events') ? true : Object.keys(values.sub_events).length === 0;
-    const subEvent = values.hasOwnProperty('start_time')
+    const subEvent = values.hasOwnProperty(type)
 
     if (subEvent || isSingleMain) {
         validations.forEach((val) => {
-            if (!validationFn[val](values, values['start_time'])) {
+            if (!validationFn[val](values, values[type])) {
                 errors.push(val)
             }
         })


### PR DESCRIPTION
# Validation for value 'end_time'

## Added validation 'required' for end_time & for 'end_time' inside sub_events 

### Trello: [LIN197](https://trello.com/c/0Y5eccYc/197-ux-aika-kent%C3%A4n-tyhjennys-tyhjent%C3%A4%C3%A4-my%C3%B6s-p%C3%A4iv%C3%A4n)

-----------------------------------------------------------------------------------------------
### Breakdown:

#### Validation & components
 1. src/validation/validator.js
     * Added VALIDATION_RULES.REQUIRED_STRING for value 'end_time' & for it, inside value 'sub_events'
     * Renamed **"validateStartTime"** to **"validateTimes"**. We use this function to validate both, 'start_time' & 'end_time'. Which we validate, is passed as "type" prop, defined as string. We pass the value into type in "else if (key === X)"
   
 2. src/components/CustomFormFields/Dateinputs/CustomDateTime.js
     * Removed logic from **"componentDidUpdate"*** -lifecycle as we do not need it to set values to states.
     * Inputs "invalid" -prop now works conditionally based on inputs value, this  way we do not show input-field as invalid even if it has value, and other doesn't.
     * Same for ValidationNotifications "validationErrors" -prop
    
 3. src/components/CustomFormFields/Dateinputs/tests/CustomDateTime.test.js 
     * Updated & added tests
     
 4. src/components/CustomFormFields/Dateinputs/CustomDateTime.scss
     * Added some z-index for popper, validation-message was overlapping with it.
     
     
# Testing enviroments before PR can be merged:

- [x] Create new event filling form correctly
- [x] Create new event filling form incorrectly & then fixing
- [x] Create draft filling form correctly
- [x] Create draft filling form incorrectly
- [x] Edit existing event
- [x] Create super_event = series
- [x] Add new sub into existing series