### PR TITLE
LIN101-publisherField

### DIFF
--- a/src/components/HelFormFields/OrganizationSelector.js
+++ b/src/components/HelFormFields/OrganizationSelector.js
@@ -21,7 +21,7 @@ const OrganizationSelector = ({formType, selectedOption, options, onChange}) => 
             <label className='event-publisher' htmlFor='event-publisher'>{<FormattedMessage id='event-publisher' />}</label>
             {formType === 'update' ? (
                 <Input
-                    className='event-publisher-input'
+                    className='event-publisher-input-disabled'
                     id='event-publisher'
                     aria-disabled={true}
                     value={label}
@@ -42,7 +42,7 @@ const OrganizationSelector = ({formType, selectedOption, options, onChange}) => 
             ) : (
                 <Input
                     readOnly
-                    className='event-publisher-input'
+                    className='event-publisher-input-disabled'
                     id='event-publisher'
                     aria-disabled={true}
                     value={get(options, '[0].label', '')}

--- a/src/components/HelFormFields/OrganizationSelector.scss
+++ b/src/components/HelFormFields/OrganizationSelector.scss
@@ -18,4 +18,8 @@
       border: solid 3px;
       border-color: var(--main-color);
     }
+    &-disabled {
+        border: none;
+        cursor: default;
+    }
 }

--- a/src/components/HelFormFields/tests/OrganizationSelector.test.js
+++ b/src/components/HelFormFields/tests/OrganizationSelector.test.js
@@ -43,7 +43,7 @@ describe('OrganizationSelector', () => {
                 const selectedOption = testOrgB
                 const input = getWrapper({formType, selectedOption}).find(Input)
                 expect(input).toHaveLength(1)
-                expect(input.prop('className')).toBe('event-publisher-input')
+                expect(input.prop('className')).toBe('event-publisher-input-disabled')
                 expect(input.prop('id')).toBe('event-publisher')
                 expect(input.prop('aria-disabled')).toBe(true)
                 expect(input.prop('value')).toBe(testOrgB.label)
@@ -73,7 +73,7 @@ describe('OrganizationSelector', () => {
             test('readonly input when there is only one option', () => {
                 const input = getWrapper().find(Input)
                 expect(input).toHaveLength(1)
-                expect(input.prop('className')).toBe('event-publisher-input')
+                expect(input.prop('className')).toBe('event-publisher-input-disabled')
                 expect(input.prop('id')).toBe('event-publisher')
                 expect(input.prop('aria-disabled')).toBe(true)
                 expect(input.prop('value')).toBe(defaultProps.options[0].label)


### PR DESCRIPTION
# LIN-101 & temporary(component itself needs rework later) changes to how field is displayed

## Changed classNames

### [LIN-101](https://trello.com/c/jWZ0iT4y/101-tapahtumaeditorin-tapahtuman-julkaisija-kent%C3%A4lle-loogisempi-muoto)

-----------------------------------------------------------------------------------------------
### Breakdown:

#### Changes
 1. src/components/HelFormFields/OrganizationSelector.js
     * Changed className in **aria-disabled={true}** inputs to be **"event-publisher-input-disabled"**
     * This className adds styling which removes borders & changes cursor to default, so some users don't think they can write into it.
   
 2. src/components/HelFormFields/OrganizationSelector.scss 
     * Added styling for "-disabled"
    
 3. src/components/HelFormFields/tests/OrganizationSelector.test.js
     * Updated classNames into tests