### PR TITLE
Added earlier deleted prevProps back

### DIFF
--- a/src/components/CustomFormFields/Dateinputs/CustomDateTime.js
+++ b/src/components/CustomFormFields/Dateinputs/CustomDateTime.js
@@ -130,6 +130,12 @@ class CustomDateTime extends React.Component {
                 this.validateDate(moment(datetimeString, getDateFormat('date-time'), true), minDate)
             }
         }
+        if (prevProps.defaultValue !== this.props.defaultValue) {
+            this.setState({
+                dateInputValue: this.props.defaultValue ? convertDateToLocaleString(this.props.defaultValue, 'date') : dateInputValue,
+                timeInputValue: this.props.defaultValue ? convertDateToLocaleString(this.props.defaultValue, 'time') : timeInputValue,
+            })
+        }
     }
 
 


### PR DESCRIPTION
# Reverted customDateTime.js - changes from #255 in componentDidUpdate

If previous prop doesn't match new, setStates like before, but instead of returning empty string if value doesn't exist, return inputs value