### PR TITLE
LIN231 disable inputs if no user

### DIFF
--- a/src/components/FormFields/index.scss
+++ b/src/components/FormFields/index.scss
@@ -363,6 +363,9 @@ h4 {
 }
 .mainwrapper {
     background-color: white;
+    .row-loginwarning ~ div {
+        pointer-events: none;
+    }
     .show {
         background-color: white;
     }


### PR DESCRIPTION
Changes:
- Added scss rules that disable pointer-events on the editor page if no user is found. The `.row-loginwarning` element is only rendered if the user is not logged in.

[Link to the trello card for this issue.](https://trello.com/c/iuYu0spO/231-ux-vaadi-kirjautuminen-ennen-mahdollisuutta-sy%C3%B6tt%C3%A4%C3%A4-yht%C3%A4%C3%A4n-mit%C3%A4%C3%A4n)