### PR TITLE
LIN231 input disable rework

### DIFF
--- a/src/components/FormFields/FormFields.test.js
+++ b/src/components/FormFields/FormFields.test.js
@@ -128,7 +128,7 @@ describe('FormField', () => {
                 const expectedValue = {sub_events: {}}
                 instance.toggleEventType({target: {value: 'recurring'}})
                 setData.mockClear()
-            
+
                 expect(wrapper.state().selectEventType).toBe('recurring')
                 instance.toggleEventType({target: {value: 'single'}})
                 expect(setData).toHaveBeenCalledWith(expectedValue)
@@ -234,7 +234,7 @@ describe('FormField', () => {
             })
         })
     })
-    
+
     describe('render', () => {
 
         describe('components', () => {
@@ -272,6 +272,7 @@ describe('FormField', () => {
                     multifields.forEach((element) => {
                         expect(element.prop('languages')).toBe(defaultProps.editor.contentLanguages)
                         expect(element.prop('setDirtyState')).toBe(defaultProps.setDirtyState)
+                        expect(element.prop('disabled')).toBe(false)
                     })
                 })
                 test('correct props for event headline', () => {
@@ -353,6 +354,7 @@ describe('FormField', () => {
                     expect(helcheckbox.prop('name')).toBe('is_virtualevent')
                     expect(helcheckbox.prop('label')).toEqual(<FormattedMessage id='event-location-virtual'/>)
                     expect(helcheckbox.prop('fieldID')).toBe('is_virtual')
+                    expect(helcheckbox.prop('disabled')).toBe(false)
                 })
             })
             describe('HelTextField', () => {
@@ -376,6 +378,7 @@ describe('FormField', () => {
                     expect(virtualHelText.prop('label')).toBe(defaultProps.intl.formatMessage({id: 'event-location-virtual-url'}))
                     expect(virtualHelText.prop('validationErrors')).toBe(defaultProps.editor.validationErrors.virtualevent_url)
                     expect(virtualHelText.prop('defaultValue')).toBe(defaultProps.editor.values.virtualevent_url)
+                    expect(virtualHelText.prop('disabled')).toBe(true)
                 })
                 test('correct props for event facebook field', () => {
                     const faceHelText = helfields.at(1)
@@ -385,6 +388,7 @@ describe('FormField', () => {
                     expect(faceHelText.prop('label')).toBe('Facebook')
                     expect(faceHelText.prop('validationErrors')).toBe(defaultProps.editor.validationErrors.extlink_facebook)
                     expect(faceHelText.prop('defaultValue')).toBe(defaultProps.editor.values.extlink_facebook)
+                    expect(faceHelText.prop('disabled')).toBe(false)
                 })
                 test('correct props for event twitter field', () => {
                     const twitterHelText = helfields.at(2)
@@ -394,6 +398,7 @@ describe('FormField', () => {
                     expect(twitterHelText.prop('label')).toBe('Twitter')
                     expect(twitterHelText.prop('validationErrors')).toBe(defaultProps.editor.validationErrors.extlink_twitter)
                     expect(twitterHelText.prop('defaultValue')).toBe(defaultProps.editor.values.extlink_twitter)
+                    expect(twitterHelText.prop('disabled')).toBe(false)
                 })
                 test('correct props for event instagram field', () => {
                     const instaHelText = helfields.at(3)
@@ -403,6 +408,7 @@ describe('FormField', () => {
                     expect(instaHelText.prop('label')).toBe('Instagram')
                     expect(instaHelText.prop('validationErrors')).toBe(defaultProps.editor.validationErrors.extlink_instagram)
                     expect(instaHelText.prop('defaultValue')).toBe(defaultProps.editor.values.extlink_instagram)
+                    expect(instaHelText.prop('disabled')).toBe(false)
                 })
             })
             describe('HelLabeledCheckboxGroup', () => {
@@ -415,6 +421,7 @@ describe('FormField', () => {
                     helgroupboxes.forEach((element)=> {
                         expect(element.prop('setDirtyState')).toBe(defaultProps.setDirtyState)
                         expect(element.prop('itemClassName')).toBe('col-md-12 col-lg-6')
+                        expect(element.prop('disabled')).toBe(false)
                     })
                 })
                 test('correct props for audience checkboxgroup', () => {
@@ -440,6 +447,7 @@ describe('FormField', () => {
                 test('correct props for HelLanguageSelect ', () => {
                     expect(hellangselect.prop('options')).toEqual(API.eventInfoLanguages())
                     expect(hellangselect.prop('checked')).toBe(defaultProps.editor.contentLanguages)
+                    expect(hellangselect.prop('disabled')).toBe(false)
                 })
             })
             describe('HelSelect', () => {
@@ -454,6 +462,7 @@ describe('FormField', () => {
                     expect(helselect.prop('optionalWrapperAttributes')).toEqual({className: 'location-select'})
                     expect(helselect.prop('currentLocale')).toBe(intl.locale)
                     expect(helselect.prop('required')).toBe(true)
+                    expect(helselect.prop('disabled')).toBe(false)
                 })
             })
             describe('HelOffersField', () => {
@@ -465,6 +474,7 @@ describe('FormField', () => {
                     expect(heloffers.prop('defaultValue')).toBe(defaultProps.editor.values.offers)
                     expect(heloffers.prop('languages')).toBe(defaultProps.editor.contentLanguages)
                     expect(heloffers.prop('setDirtyState')).toBe(defaultProps.setDirtyState)
+                    expect(heloffers.prop('disabled')).toBe(false)
                 })
             })
 
@@ -476,6 +486,7 @@ describe('FormField', () => {
                     expect(helkeywords.prop('intl')).toBe(intl)
                     expect(helkeywords.prop('setDirtyState')).toBe(defaultProps.setDirtyState)
                     expect(helkeywords.prop('currentLocale')).toBe(intl.locale)
+                    expect(helkeywords.prop('disabled')).toBe(false)
                 })
             })
 
@@ -512,6 +523,7 @@ describe('FormField', () => {
                     expect(umbrella.prop('editor')).toBe(defaultProps.editor)
                     expect(umbrella.prop('event')).toBe(defaultProps.event)
                     expect(umbrella.prop('superEvent')).toBe(defaultProps.editor.super_event_type)
+                    expect(umbrella.prop('disabled')).toBe(false)
                 })
             })
             describe('HelVideoFields', () => {
@@ -523,6 +535,7 @@ describe('FormField', () => {
                     expect(videofields.prop('setDirtyState')).toBe(defaultProps.setDirtyState)
                     expect(videofields.prop('intl')).toBe(intl)
                     expect(videofields.prop('action')).toBe(defaultProps.action)
+                    expect(videofields.prop('disabled')).toBe(false)
                 })
             })
             describe('CustomDateTime', () => {
@@ -614,7 +627,7 @@ describe('FormField', () => {
                     const message = getWrapper().find('#event-location-button')
                     expect(message).toHaveLength(1)
                 })
-                
+
                 test('button icon when state.openMapContainer is true', () => {
                     const wrapper = getWrapper()
                     const instance = wrapper.instance()

--- a/src/components/FormFields/index.js
+++ b/src/components/FormFields/index.js
@@ -118,7 +118,7 @@ class FormFields extends React.Component {
         if (prevState.selectEventType === 'recurring' && Object.keys(this.props.editor.values.sub_events).length === 0) {
             this.toggleEventType({target: {value: 'single'}})
         }
-        
+
         // if recurring was previously false and is true now -> reset back to false
         if(!prevState.createdRecurringEvents && this.state.createdRecurringEvents){
             this.setState({createdRecurringEvents: false})
@@ -307,7 +307,9 @@ class FormFields extends React.Component {
         const position = this.props.editor.values.location ? this.props.editor.values.location.position : null;
         const headerTextId = formType === 'update'
             ? 'edit-events'
-            : 'create-events'
+            : 'create-events';
+        // This variable is used to disable inputs if user doesn't exist.
+        const userDoesNotExist = !user;
 
         return (
             <div className='mainwrapper'>
@@ -327,7 +329,7 @@ class FormFields extends React.Component {
                 </div>
                 <FormHeader messageID='event-type-select'/>
                 <div className='row'>
-                    <TypeSelector editor={this.props.editor} event={event}/>
+                    <TypeSelector editor={this.props.editor} event={event} disabled={userDoesNotExist}/>
                 </div>
                 <FormHeader messageID='event-presented-in-languages'/>
                 <FormHeader messageID='event-presented-in-languages2' type='h4'/>
@@ -336,6 +338,7 @@ class FormFields extends React.Component {
                         <HelLanguageSelect
                             options={API.eventInfoLanguages()}
                             checked={contentLanguages}
+                            disabled={userDoesNotExist}
                         />
                     </div>
                 </div>
@@ -356,6 +359,7 @@ class FormFields extends React.Component {
                             defaultValue={values['name']}
                             languages={this.props.editor.contentLanguages}
                             setDirtyState={this.props.setDirtyState}
+                            disabled={userDoesNotExist}
                         />
 
                         <MultiLanguageField
@@ -371,6 +375,7 @@ class FormFields extends React.Component {
                             setDirtyState={this.props.setDirtyState}
                             forceApplyToStore
                             type='textarea'
+                            disabled={userDoesNotExist}
                         />
                         <MultiLanguageField
                             id='event-description'
@@ -384,6 +389,7 @@ class FormFields extends React.Component {
                             validations={[VALIDATION_RULES.LONG_STRING]}
                             setDirtyState={this.props.setDirtyState}
                             type='textarea'
+                            disabled={userDoesNotExist}
                         />
                         <OrganizationSelector
                             formType={formType}
@@ -404,6 +410,7 @@ class FormFields extends React.Component {
                             languages={this.props.editor.contentLanguages}
                             setDirtyState={this.props.setDirtyState}
                             type='textarea'
+                            disabled={userDoesNotExist}
                         />
                     </div>
                 </div>
@@ -543,6 +550,7 @@ class FormFields extends React.Component {
                                         label={<FormattedMessage id='event-location-virtual'/>}
                                         fieldID='is_virtual'
                                         defaultChecked={values['is_virtualevent']}
+                                        disabled={userDoesNotExist}
                                     />
                                     <HelTextField
                                         validations={[VALIDATION_RULES.IS_URL]}
@@ -556,7 +564,7 @@ class FormFields extends React.Component {
                                         forceApplyToStore
                                         type='url'
                                         required={values.is_virtualevent}
-                                        disabled={!values.is_virtualevent}
+                                        disabled={userDoesNotExist || !values.is_virtualevent}
                                     />
                                 </div>
                                 <HelSelect
@@ -570,6 +578,7 @@ class FormFields extends React.Component {
                                     optionalWrapperAttributes={{className: 'location-select'}}
                                     currentLocale={currentLocale}
                                     required={!values.is_virtualevent}
+                                    disabled={userDoesNotExist}
                                 />
                                 <div className='map-button-container'>
                                     <Button
@@ -625,6 +634,7 @@ class FormFields extends React.Component {
                                     languages={this.props.editor.contentLanguages}
                                     setDirtyState={this.props.setDirtyState}
                                     type='textarea'
+                                    disabled={userDoesNotExist}
                                 />
                             </div>
                         </div>
@@ -637,7 +647,7 @@ class FormFields extends React.Component {
                                     <p><FormattedMessage id="editor-tip-umbrella-selection1"/></p>
                                 </SideField>
                                 <div className="col-sm-6">
-                                    <UmbrellaSelector editor={this.props.editor} event={event} superEvent={superEvent}/>
+                                    <UmbrellaSelector editor={this.props.editor} event={event} superEvent={superEvent} disabled={userDoesNotExist}/>
                                 </div>
                             </div>
                         </React.Fragment>
@@ -663,11 +673,13 @@ class FormFields extends React.Component {
                                             onChange={this.toggleEventType}
                                             checked={!this.state.selectEventType}
                                             disabled={
+                                                userDoesNotExist ||
                                                 formType === 'update' ||
-                                                        formType === 'add' ||
-                                                        isSuperEventDisable ||
-                                                        isSuperEvent ||
-                                                        subTimeDisable}
+                                                formType === 'add' ||
+                                                isSuperEventDisable ||
+                                                isSuperEvent ||
+                                                subTimeDisable
+                                            }
                                         />
                                         <label className='custom-control-label' htmlFor='single'>
                                             <FormattedMessage id='event-type-single'/>
@@ -683,11 +695,14 @@ class FormFields extends React.Component {
                                             value='recurring'
                                             checked={this.state.selectEventType}
                                             onChange={this.toggleEventType}
-                                            disabled={formType === 'update' ||
-                                                    formType === 'add' ||
-                                                    isSuperEventDisable ||
-                                                    isSuperEvent ||
-                                                    values.start_time !== undefined}
+                                            disabled={
+                                                userDoesNotExist ||
+                                                formType === 'update' ||
+                                                formType === 'add' ||
+                                                isSuperEventDisable ||
+                                                isSuperEvent ||
+                                                values.start_time !== undefined
+                                            }
                                         />
                                         <label className='custom-control-label' htmlFor='recurring'>
                                             <FormattedMessage id='event-type-recurring'/>
@@ -713,13 +728,13 @@ class FormFields extends React.Component {
                                             setDirtyState={this.props.setDirtyState}
                                             maxDate={values['end_time'] ? moment(values['end_time']) : undefined}
                                             required={true}
-                                            disabled={formType === 'update' && isSuperEvent}
+                                            disabled={userDoesNotExist || (formType === 'update' && isSuperEvent)}
                                             validationErrors={validationErrors['start_time']}
                                         />
                                         <CustomDateTime
                                             id="end_time"
                                             disablePast
-                                            disabled={formType === 'update' && isSuperEvent}
+                                            disabled={userDoesNotExist || (formType === 'update' && isSuperEvent)}
                                             validationErrors={validationErrors['end_time']}
                                             defaultValue={values['end_time']}
                                             name="end_time"
@@ -828,6 +843,7 @@ class FormFields extends React.Component {
                                 intl={this.context.intl}
                                 setDirtyState={this.props.setDirtyState}
                                 currentLocale={currentLocale}
+                                disabled={userDoesNotExist}
                             />
                         </div>
                         <div className="row audience-row">
@@ -840,6 +856,7 @@ class FormFields extends React.Component {
                                 itemClassName="col-md-12 col-lg-6"
                                 options={helTargetOptions}
                                 setDirtyState={this.props.setDirtyState}
+                                disabled={userDoesNotExist}
                             />
                         </div>
                     </Collapse>
@@ -865,6 +882,7 @@ class FormFields extends React.Component {
                                     defaultValue={values['offers']}
                                     languages={this.props.editor.contentLanguages}
                                     setDirtyState={this.props.setDirtyState}
+                                    disabled={userDoesNotExist}
                                 />
                             </div>
 
@@ -900,6 +918,7 @@ class FormFields extends React.Component {
                                     forceApplyToStore
                                     type='url'
                                     placeholder='https://...'
+                                    disabled={userDoesNotExist}
                                 />
                                 <HelTextField
                                     validations={[VALIDATION_RULES.IS_URL]}
@@ -913,6 +932,7 @@ class FormFields extends React.Component {
                                     forceApplyToStore
                                     type='url'
                                     placeholder='https://...'
+                                    disabled={userDoesNotExist}
                                 />
                                 <i className='facebookIcon' />
                                 <HelTextField
@@ -927,6 +947,7 @@ class FormFields extends React.Component {
                                     forceApplyToStore
                                     type='url'
                                     placeholder='https://...'
+                                    disabled={userDoesNotExist}
                                 />
                                 <HelTextField
                                     validations={[VALIDATION_RULES.IS_URL]}
@@ -940,6 +961,7 @@ class FormFields extends React.Component {
                                     forceApplyToStore
                                     type='url'
                                     placeholder='https://...'
+                                    disabled={userDoesNotExist}
                                 />
                             </div>
                         </div>
@@ -949,6 +971,7 @@ class FormFields extends React.Component {
                             setDirtyState={this.props.setDirtyState}
                             intl={this.context.intl}
                             action={this.props.action}
+                            disabled={userDoesNotExist}
                         />
                     </Collapse>
                 </div>
@@ -973,6 +996,7 @@ class FormFields extends React.Component {
                                 itemClassName="col-md-12 col-lg-6"
                                 options={helEventLangOptions}
                                 setDirtyState={this.props.setDirtyState}
+                                disabled={userDoesNotExist}
                             />
                         </div>
                     </Collapse>

--- a/src/components/FormFields/index.scss
+++ b/src/components/FormFields/index.scss
@@ -363,7 +363,8 @@ h4 {
 }
 .mainwrapper {
     background-color: white;
-    .row-loginwarning ~ div {
+    .row-loginwarning ~ div.row,
+    .row-loginwarning ~ div  div.collapse{
         pointer-events: none;
     }
     .show {

--- a/src/components/HelFormFields/HelCheckbox.js
+++ b/src/components/HelFormFields/HelCheckbox.js
@@ -62,6 +62,7 @@ class HelCheckbox extends React.Component {
                     id={fieldID}
                     aria-checked={defaultChecked}
                     aria-disabled={disabled}
+                    disabled={disabled}
                 />
                 <label className={classNames('custom-control-label', {disabled: disabled})}  htmlFor={fieldID}>
                     {label}

--- a/src/components/HelFormFields/HelKeywordSelector/HelKeywordSelector.js
+++ b/src/components/HelFormFields/HelKeywordSelector/HelKeywordSelector.js
@@ -5,7 +5,6 @@ import {connect} from 'react-redux'
 import {FormattedMessage} from 'react-intl'
 import {HelLabeledCheckboxGroup, HelSelect} from '../index'
 import SelectedKeywords from '../../SelectedKeywords/SelectedKeywords'
-import {SideField} from '../../FormFields'
 import {mapKeywordSetToForm} from '../../../utils/apiDataMapping'
 import {setData as setDataAction} from '../../../actions/editor'
 import {CopyToClipboard} from 'react-copy-to-clipboard'
@@ -49,7 +48,7 @@ const getKeywordIds = (keywords) => keywords
     })
     .join()
 
-const HelKeywordSelector = ({intl, editor, setDirtyState, setData, currentLocale}) => {
+const HelKeywordSelector = ({intl, editor, setDirtyState, setData, currentLocale, disabled}) => {
     const [isRemoteEvent, toggleIsRemoteEvent] = useState(false);
     const {values, keywordSets, validationErrors} = editor
     let keywords = get(values, 'keywords', [])
@@ -99,6 +98,7 @@ const HelKeywordSelector = ({intl, editor, setDirtyState, setData, currentLocale
                 groupLabel={<FormattedMessage id="main-categories-header"/>}
                 selectedValues={keywords}
                 name="keywords"
+                disabled={disabled}
                 validationErrors={validationErrors['keywords']}
                 itemClassName="col-md-12 col-lg-6"
                 options={parsedMainCategoryOptions}
@@ -113,6 +113,7 @@ const HelKeywordSelector = ({intl, editor, setDirtyState, setData, currentLocale
                     legend={intl.formatMessage({id: 'event-keywords'})}
                     name="keywords"
                     resource="keyword"
+                    disabled={disabled}
                     setDirtyState={setDirtyState}
                     customOnChangeHandler={(selectedOption) =>
                         handleKeywordChange(selectedOption, keywords, mainCategoryOptions, setData)
@@ -144,6 +145,7 @@ HelKeywordSelector.propTypes = {
     setDirtyState: PropTypes.func,
     editor: PropTypes.object,
     currentLocale: PropTypes.string,
+    disabled: PropTypes.bool,
 }
 
 const mapDispatchToProps = (dispatch) => ({

--- a/src/components/HelFormFields/HelLabeledCheckboxGroup.js
+++ b/src/components/HelFormFields/HelLabeledCheckboxGroup.js
@@ -28,7 +28,7 @@ const handleChange = (refs, {options, name, customOnChangeHandler, setDirtyState
 }
 
 const HelLabeledCheckboxGroup = (props) => {
-    const {options, name, selectedValues, itemClassName, groupLabel, validationErrors} = props
+    const {options, name, selectedValues, itemClassName, groupLabel, validationErrors, disabled} = props
     const refs = useRef({}).current;
     const labelRef = useRef(null);
     const checkedOptions = selectedValues.map(item => {
@@ -62,6 +62,7 @@ const HelLabeledCheckboxGroup = (props) => {
                                     checked={checked}
                                     onChange={() => handleChange(refs, props)}
                                     id={inputId}
+                                    disabled={disabled}
                                 />
                                 <label htmlFor={inputId} className='custom-control-label'>{item.label}</label>
                             </div>
@@ -86,6 +87,7 @@ HelLabeledCheckboxGroup.propTypes = {
     name: PropTypes.string,
     customOnChangeHandler: PropTypes.func,
     setData: PropTypes.func,
+    disabled: PropTypes.bool,
     setDirtyState: PropTypes.func,
     selectedValues: PropTypes.array,
     options: PropTypes.array,

--- a/src/components/HelFormFields/HelLanguageSelect.js
+++ b/src/components/HelFormFields/HelLanguageSelect.js
@@ -37,11 +37,11 @@ class HelLanguageSelect extends React.Component {
     };
 
     render() {
-        const {options, checked} = this.props;
+        const {options, checked, disabled} = this.props;
         const checkboxes = options.map((item, index) => {
             const checkedOptions = checked;
             const isChecked = checkedOptions && checkedOptions.includes(item.value);
-            const disabled = isChecked && checkedOptions && checkedOptions.length === 1;
+            const isDisabled = disabled || (isChecked && checkedOptions && checkedOptions.length === 1);
 
             return (
                 <div className='custom-control custom-checkbox' key={index}>
@@ -55,9 +55,10 @@ class HelLanguageSelect extends React.Component {
                         checked={isChecked}
                         onChange={this.onChange}
                         aria-checked={isChecked}
-                        aria-disabled={disabled}
+                        aria-disabled={isDisabled}
+                        disabled={disabled}
                     />
-                    <label className={classNames('custom-control-label', {disabled: disabled})} htmlFor={`checkBox-${item.value}`}>
+                    <label className={classNames('custom-control-label', {disabled: isDisabled})} htmlFor={`checkBox-${item.value}`}>
                         <FormattedMessage id={item.label} />
                     </label>
                 </div>
@@ -73,6 +74,7 @@ HelLanguageSelect.propTypes = {
     onChange: PropTypes.func,
     options: PropTypes.array,
     checked: PropTypes.array,
+    disabled: PropTypes.bool,
 };
 
 const mapDispatchToProps = (dispatch) => ({

--- a/src/components/HelFormFields/HelOffersField.js
+++ b/src/components/HelFormFields/HelOffersField.js
@@ -79,6 +79,7 @@ class HelOffersField extends React.Component {
                         languages={this.props.languages}
                         isFree={this.state.isFree}
                         setInitialFocus={key === firstKey}
+                        disabled={this.props.disabled}
                     />
                 );
             }
@@ -88,16 +89,18 @@ class HelOffersField extends React.Component {
 
     render() {
         const {values} = this.state;
+        const {disabled} = this.props;
         const offerDetails = this.generateOffers(this.props.defaultValue);
         //Change OFFER_LENGTH in constants to change maximum length of prices users can add, currently limited to 20
         const isOverLimit = values && values.length >= GENERATE_LIMIT.OFFER_LENGTH;
-        const disabled = isOverLimit || this.state.isFree;
+        const disabledButton = disabled || isOverLimit || this.state.isFree;
 
         return (
             <Fragment>
                 <HelCheckbox
                     fieldID='is-free-checkbox'
                     defaultChecked={this.state.isFree}
+                    disabled={disabled}
                     ref='is_free'
                     label={<FormattedMessage id='is-free' />}
                     onChange={(e, v) => this.setIsFree(e, v)}
@@ -109,7 +112,7 @@ class HelOffersField extends React.Component {
                     <Button
                         size='lg'block
                         variant="contained"
-                        disabled={disabled}
+                        disabled={disabledButton}
                         onClick={() => this.addNewOffer()}
                     ><span aria-hidden className="glyphicon glyphicon-plus"></span>
                         <FormattedMessage id="event-add-price" />
@@ -129,6 +132,7 @@ HelOffersField.propTypes = {
     defaultValue: PropTypes.array,
     validationErrors: PropTypes.oneOfType([PropTypes.array, PropTypes.object]),
     languages: PropTypes.array,
+    disabled: PropTypes.bool,
 };
 
 export default HelOffersField;

--- a/src/components/HelFormFields/HelSelect.js
+++ b/src/components/HelFormFields/HelSelect.js
@@ -28,6 +28,7 @@ const HelSelect = ({
     currentLocale,
     required,
     inputValue,
+    disabled,
 })  => {
     const labelRef = useRef(null)
     const selectInputRef = useRef(null)
@@ -56,7 +57,7 @@ const HelSelect = ({
             parentDiv.insertBefore(newDiv, input)
         }
     }, [name])
-    
+
     const onChange = (value) => {
         // let the custom handler handle the change if given
         if (typeof customOnChangeHandler === 'function') {
@@ -248,11 +249,12 @@ const HelSelect = ({
                 aria-label={intl.formatMessage({id: placeholderId})}
                 ref={selectInputRef}
                 styles={{control: invalidStyles}}
+                isDisabled={disabled}
             />
             <ValidationNotification
                 anchor={labelRef.current}
                 validationErrors={validationErrors}
-                className='validation-select' 
+                className='validation-select'
             />
         </div>
     )
@@ -272,6 +274,7 @@ HelSelect.propTypes = {
     name: PropTypes.string,
     isClearable: PropTypes.bool,
     isMultiselect: PropTypes.bool,
+    disabled: PropTypes.bool,
     setDirtyState: PropTypes.func,
     resource: PropTypes.string,
     legend: PropTypes.string,

--- a/src/components/HelFormFields/HelVideoFields/HelVideoFields.js
+++ b/src/components/HelFormFields/HelVideoFields/HelVideoFields.js
@@ -2,10 +2,8 @@ import './HelVideoFields.scss';
 
 import React from 'react';
 import PropTypes from 'prop-types';
-import {FormattedMessage} from 'react-intl';
 import {setData as setDataAction} from 'src/actions/editor';
 import {HelTextField, MultiLanguageField} from '../index';
-import {SideField} from '../../FormFields';
 import {connect} from 'react-redux';
 import classNames from 'classnames';
 import {isEmpty, get} from 'lodash';
@@ -242,6 +240,7 @@ class HelVideoFields extends React.Component {
                                         onBlur={(e, v) => this.handleBlur(e, v, this.state.videos)}
                                         placeholder='https://...'
                                         type='url'
+                                        disabled={this.props.disabled}
                                     />
                                     <MultiLanguageField
                                         id='event-video-name'
@@ -255,6 +254,7 @@ class HelVideoFields extends React.Component {
                                         onChange={(e, v) => this.handleChange(e, v, 'name', index)}
                                         onBlur={(e, v) => this.handleBlur(e, v, this.state.videos)}
                                         type='text'
+                                        disabled={this.props.disabled}
                                     />
                                     <MultiLanguageField
                                         id='event-video-alt_text'
@@ -268,6 +268,7 @@ class HelVideoFields extends React.Component {
                                         onChange={(e, v) => this.handleChange(e, v, 'alt_text', index)}
                                         onBlur={(e, v) => this.handleBlur(e, v, this.state.videos)}
                                         type='text'
+                                        disabled={this.props.disabled}
                                     />
                                 </div>
                             </div>
@@ -298,6 +299,7 @@ HelVideoFields.propTypes = {
     action: PropTypes.string,
     setData: PropTypes.func,
     defaultValues: PropTypes.array,
+    disabled: PropTypes.bool,
     validationErrors: PropTypes.object,
     setDirtyState: PropTypes.func,
     languages: PropTypes.array,

--- a/src/components/HelFormFields/NewOffer.js
+++ b/src/components/HelFormFields/NewOffer.js
@@ -77,7 +77,7 @@ class NewOffer extends React.Component {
     }
 
     render() {
-        const {offerKey, defaultValue, isFree, languages, intl, length} = this.props
+        const {offerKey, defaultValue, isFree, languages, intl, length, disabled} = this.props
         const {VALIDATION_RULES} = CONSTANTS
 
         return (
@@ -92,7 +92,7 @@ class NewOffer extends React.Component {
                         name='price'
                         min={0}
                         defaultValue={defaultValue.price}
-                        disabled={isFree}
+                        disabled={disabled || isFree}
                         ref="price"
                         label="event-price"
                         languages={languages}
@@ -108,7 +108,7 @@ class NewOffer extends React.Component {
                     <MultiLanguageField
                         id={'event-price-info' + this.props.offerKey}
                         defaultValue={defaultValue.description}
-                        disabled={isFree}
+                        disabled={disabled || isFree}
                         ref="description"
                         label="event-price-info"
                         languages={languages}
@@ -123,6 +123,7 @@ class NewOffer extends React.Component {
                     <MultiLanguageField
                         id={'event-purchase-link' + this.props.offerKey}
                         defaultValue={defaultValue.info_url}
+                        disabled={disabled}
                         ref="info_url"
                         label="event-purchase-link"
                         languages={languages}
@@ -157,6 +158,7 @@ NewOffer.propTypes = {
     intl: intlShape,
     setInitialFocus: PropTypes.bool,
     length: PropTypes.number,
+    disabled: PropTypes.bool,
 }
 
 export default injectIntl(NewOffer);

--- a/src/components/HelFormFields/Selectors/TypeSelector.js
+++ b/src/components/HelFormFields/Selectors/TypeSelector.js
@@ -140,6 +140,7 @@ class TypeSelector extends React.Component {
 
     render() {
         const {type, isCreateView} = this.state
+        const {disabled} = this.props;
 
         return (
             <div className="type-row row">
@@ -151,7 +152,7 @@ class TypeSelector extends React.Component {
                             checked={type === 'event'}
                             handleCheck={this.handleCheck}
                             messageID='event'
-                            disabled={!isCreateView}
+                            disabled={disabled || !isCreateView}
                             name='TypeGroup'
                         >
 
@@ -173,7 +174,7 @@ class TypeSelector extends React.Component {
                             ariaLabel={this.context.intl.formatMessage({id: `hobby`})}
                             value='hobby'
                             checked={type === 'hobby'}
-                            disabled={!isCreateView}
+                            disabled={disabled || !isCreateView}
                             handleCheck={this.handleCheck}
                             messageID='hobby'
                             name='TypeGroup'
@@ -196,6 +197,7 @@ TypeSelector.propTypes = {
     isUmbrellaEvent: PropTypes.bool,
     hasUmbrellaEvent: PropTypes.bool,
     editedEventIsSubEvent: PropTypes.bool,
+    disabled: PropTypes.bool,
 }
 
 TypeSelector.contextTypes = {

--- a/src/components/HelFormFields/Selectors/UmbrellaSelector.js
+++ b/src/components/HelFormFields/Selectors/UmbrellaSelector.js
@@ -179,7 +179,7 @@ class UmbrellaSelector extends React.Component {
         this.setState(states);
         this.context.dispatch(clearValue(clearValues))
     }
-    
+
     /**
      * Handles select changes
      * @param selectedEvent Data for the selected event
@@ -222,10 +222,11 @@ class UmbrellaSelector extends React.Component {
      */
     getDisabledState = (value, editedEventIsSubEvent) => {
         const {isCreateView, superEventSuperEventType} = this.state
-        const {event, editor: {values}} = this.props
+        const {event, editor: {values}, disabled} = this.props
         const editedEventIsAnUmbrellaEvent = get(event, 'super_event_type') === constants.SUPER_EVENT_TYPE_UMBRELLA
         const editedEventIsARecurringEvent = get(event, 'super_event_type') === constants.SUPER_EVENT_TYPE_RECURRING
         const editedEventHasSubEvents = get(event, 'sub_events', []).length > 0
+        if (disabled) {return disabled;}
         if (value === 'is_independent') {
             return isCreateView
                 ? false
@@ -340,6 +341,7 @@ class UmbrellaSelector extends React.Component {
 UmbrellaSelector.propTypes = {
     intl: PropTypes.object,
     dispatch: PropTypes.func,
+    disabled: PropTypes.bool,
     store: PropTypes.object,
     editor: PropTypes.object,
     event: PropTypes.object,

--- a/src/components/HelFormFields/tests/HelLanguageSelect.test.js
+++ b/src/components/HelFormFields/tests/HelLanguageSelect.test.js
@@ -12,6 +12,7 @@ const defaultProps = {
     onChange: () => {},
     setLanguages: () => {},
     checked: ['fi'],
+    disabled: false,
 };
 
 describe('HelLanguageSelect', () => {
@@ -29,7 +30,7 @@ describe('HelLanguageSelect', () => {
             expect(div.at(1).prop('className')).toBe('custom-control custom-checkbox');
         });
         describe('input checkbox', () => {
-            test('LanguageSelect input checkbox gets correct props', () => {
+            test('LanguageSelect input checkbox gets correct props based on defaultProps', () => {
                 const activeLang = availableLanguages[Math.floor(Math.random() * availableLanguages.length)];
                 const checkboxes = getWrapper({checked: [activeLang]}).find('input');
 
@@ -38,6 +39,7 @@ describe('HelLanguageSelect', () => {
                     expect(checkbox.prop('className')).toBe('custom-control-input');
                     expect(checkbox.prop('type')).toBe('checkbox');
                     expect(checkbox.prop('id')).toBe(`checkBox-${availableLanguages[index]}`);
+                    expect(checkbox.prop('disabled')).toBe(false);
                     if (availableLanguages[index] === activeLang) {
                         expect(checkbox.prop('aria-checked')).toBe(true);
                         expect(checkbox.prop('aria-disabled')).toBe(true);
@@ -45,6 +47,12 @@ describe('HelLanguageSelect', () => {
                         expect(checkbox.prop('aria-checked')).toBe(false);
                         expect(checkbox.prop('aria-disabled')).toBe(false);
                     }
+                });
+            });
+            test('LanguageSelect inputs are disabled if props.disabled = true', () => {
+                const checkboxes = getWrapper({checked: 'fi', disabled: true}).find('input');
+                checkboxes.forEach((checkbox) => {
+                    expect(checkbox.prop('disabled')).toBe(true);
                 });
             });
         });

--- a/src/components/HelFormFields/tests/HelOffersField.test.js
+++ b/src/components/HelFormFields/tests/HelOffersField.test.js
@@ -19,6 +19,7 @@ const defaultProps = {
     defaultValue: undefined,
     languages: ['fi'],
     validationErrors: {},
+    disabled: false,
 }
 
 describe('HelOffersField', () => {
@@ -28,7 +29,7 @@ describe('HelOffersField', () => {
 
     describe('renders', () => {
         describe('checkbox', () => {
-            test('correct props', () => {
+            test('correct default props', () => {
                 const wrapper = getWrapper()
                 const checkbox = wrapper.find(HelCheckbox)
                 expect(checkbox).toHaveLength(1)
@@ -36,6 +37,11 @@ describe('HelOffersField', () => {
                 expect(checkbox.prop('defaultChecked')).toBe(true)
                 expect(checkbox.prop('label')).toEqual(<FormattedMessage id='is-free'/>)
                 expect(checkbox.prop('onChange')).toBeDefined()
+                expect(checkbox.prop('disabled')).toBe(false)
+            })
+            test('disabled is true if props.disable is true', () => {
+                const checkbox = getWrapper({disabled: true}).find(HelCheckbox)
+                expect(checkbox.prop('disabled')).toBe(true)
             })
         })
         describe('button', () => {
@@ -92,7 +98,7 @@ describe('HelOffersField', () => {
             const obj = {
                 is_free: true,
             };
-            
+
             test('addNewOffer called with addOffer(object)', () => {
                 instance.addNewOffer()
                 expect(dispatch).toHaveBeenCalledWith(addOffer(obj))
@@ -168,7 +174,7 @@ describe('HelOffersField', () => {
 
                 expect(wrapper.state('values')).toEqual(expectedValue)
                 wrapper.setProps({defaultValue: undefined})
-                
+
                 expect(dispatch).toHaveBeenCalledWith(setFreeOffers(true))
             })
         })

--- a/src/components/HelFormFields/tests/HelSelect.test.js
+++ b/src/components/HelFormFields/tests/HelSelect.test.js
@@ -18,6 +18,7 @@ const defaultProps = {
     required: true,
     resource: 'place',
     validationErrors: undefined,
+    disabled: false,
 }
 
 describe('HelSelect', () => {
@@ -32,6 +33,11 @@ describe('HelSelect', () => {
                     const wrapper = getWrapper()
                     const Select = wrapper.find(AsyncSelect)
                     expect(Select).toHaveLength(1)
+                })
+                test('disabled attribute is true if props.disabled is true', () => {
+                    const wrapper = getWrapper({disabled: true})
+                    const Select = wrapper.find(AsyncSelect)
+                    expect(Select.prop('isDisabled')).toBe(true)
                 })
             })
             describe('validationNotification', () => {

--- a/src/components/HelFormFields/tests/HelVideoFields.test.js
+++ b/src/components/HelFormFields/tests/HelVideoFields.test.js
@@ -34,6 +34,7 @@ describe('HelVideoFields', () => {
         intl: {intl},
         editorValues: {},
         defaultValues: [],
+        disabled: false,
     };
     const MOCK_VIDEO = {
         url: 'http://www.turku.fi/',
@@ -270,6 +271,16 @@ describe('HelVideoFields', () => {
 
                 textFieldElements = wrapper.find(HelTextField);
                 expect(textFieldElements.at(randomKey([0, 1, 2])).prop('required')).toBe(false);
+            });
+            test('disabled attribute is determined by props.disabled', () => {
+                let elements = getWrapper({disabled: true}).find(HelTextField);
+                elements.forEach((element) => {
+                    expect(element.prop('disabled')).toBe(true);
+                });
+                elements = getWrapper({disabled: false}).find(HelTextField);
+                elements.forEach((element) => {
+                    expect(element.prop('disabled')).toBe(false);
+                });
             });
         });
     });

--- a/src/components/HelFormFields/tests/TypeSelector.test.js
+++ b/src/components/HelFormFields/tests/TypeSelector.test.js
@@ -37,6 +37,7 @@ const defaultProps = {
         },
     },
     intl,
+    disabled: false,
 }
 
 describe('UmbrellaSelector', () => {
@@ -47,7 +48,7 @@ describe('UmbrellaSelector', () => {
     describe('renders', () => {
         describe('components', () => {
             describe('SelectorRadios', () => {
-                test('correct props', () => {
+                test('correct default props', () => {
                     const wrapper = getWrapper()
                     const instance = wrapper.instance();
                     const radioElements = wrapper.find(SelectorRadio)
@@ -61,10 +62,16 @@ describe('UmbrellaSelector', () => {
                         expect(radio.prop('messageID')).toBe(elementIds[index]);
                         expect(radio.prop('value')).toBe(elementValues[index]);
                         expect(radio.prop('ariaLabel')).toBe(intl.formatMessage({id: elementIds[index]}))
-                        expect(radio.prop('disabled')).toBe(!instance.state.isCreateView)
+                        expect(radio.prop('disabled')).toBe(defaultProps.disabled || !instance.state.isCreateView)
                         expect(radio.prop('checked')).toBe(elementStates[index])
                     })
                 })
+                test('disabled attribute is true if props.disabled is true', () => {
+                    const elements = getWrapper({disabled: true}).find(SelectorRadio)
+                    elements.forEach((element) => {
+                        expect(element.prop('disabled')).toBe(true);
+                    });
+                });
             })
         })
     })

--- a/src/components/HelFormFields/tests/UmbrellaSelector.test.js
+++ b/src/components/HelFormFields/tests/UmbrellaSelector.test.js
@@ -40,6 +40,7 @@ const defaultProps = {
         },
     },
     intl,
+    disabled: false,
 }
 
 describe('UmbrellaSelector', () => {
@@ -50,7 +51,7 @@ describe('UmbrellaSelector', () => {
     describe('renders', () => {
         describe('components', () => {
             describe('UmbrellaRadios', () => {
-                test('correct props', () => {
+                test('correct default props', () => {
                     const wrapper = getWrapper()
                     const instance = wrapper.instance();
                     const radioElements = wrapper.find(SelectorRadio)
@@ -66,6 +67,12 @@ describe('UmbrellaSelector', () => {
                         expect(radio.prop('aria-label')).toBe(intl.formatMessage({id: elementIds[index]}))
                         expect(radio.prop('disabled')).toBe(instance.getDisabledState(elementValues[index]))
                         expect(radio.prop('checked')).toBe(elementStates[index])
+                    })
+                })
+                test('disabled attribute is true if props.disabled is true', () => {
+                    const elements = getWrapper({disabled: true}).find(SelectorRadio)
+                    elements.forEach((element) => {
+                        expect(element.prop('disabled')).toBe(true)
                     })
                 })
             })

--- a/src/components/ImageGallery/ImageGallery.js
+++ b/src/components/ImageGallery/ImageGallery.js
@@ -55,6 +55,7 @@ class ImageGallery extends React.Component {
                         size='lg'
                         block
                         onClick={this.toggleEditModal}
+                        disabled={!user}
                     >
                         <span aria-hidden className="glyphicon glyphicon-plus"/>
                         <FormattedMessage id='upload-new-image' />
@@ -62,7 +63,7 @@ class ImageGallery extends React.Component {
                     <ValidationNotification
                         anchor={this.validationRef.current}
                         validationErrors={validationErrors}
-                        className='validation-notification' 
+                        className='validation-notification'
                     />
                     <Button
                         className='toggleOrg'
@@ -79,6 +80,7 @@ class ImageGallery extends React.Component {
                         size='lg'
                         block
                         onClick={() => this.toggleOrgModal(true)}
+                        disabled={!user}
                     >
                         <span aria-hidden className="glyphicon glyphicon-plus"/>
                         <FormattedMessage id='select-from-default'/>
@@ -88,12 +90,12 @@ class ImageGallery extends React.Component {
                 </div>
                 <div className='col-sm-5 side-field'>
                     <div className={classNames('image-picker', {'background': backgroundImage})}>
-                        <ImagePreview 
+                        <ImagePreview
                             image={this.props.editor.values.image}
                             locale={this.props.locale}
                             validationErrors={validationErrors}
                         />
-                        
+
                     </div>
                 </div>
             </React.Fragment>


### PR DESCRIPTION
Changes:
Added disable attribute based on if user exists to all inputs/buttons found the following components:
- HelCheckbox
- HelKeywordSelector
- HelLabeledCheckboxGroup
- HelLanguageSelect
- HelOffersField
- HelSelect
- HelVideoFields
- NewOffer
- TypeSelector
- UmbrellaSelector
- ImageGallery

Modified the `pointer-events` rule so that the collapse buttons work.

[Link to trello card.](https://trello.com/c/iuYu0spO/231-ux-vaadi-kirjautuminen-ennen-mahdollisuutta-sy%C3%B6tt%C3%A4%C3%A4-yht%C3%A4%C3%A4n-mit%C3%A4%C3%A4n)