### PR TITLE
Fix to image permissions

### DIFF
--- a/src/actions/userImages.js
+++ b/src/actions/userImages.js
@@ -20,7 +20,7 @@ async function makeImageRequest(user = {}, pageSize, pageNumber = null) {
     const params = {
         page_size: pageSize,
         page: pageNumber,
-        publisher: user.organization && user.userType === constants.USER_TYPE.ADMIN ? user.organization : null,
+        publisher: user.organization && [USER_TYPE.REGULAR, USER_TYPE.PUBLIC, USER_TYPE.ADMIN].includes(user.userType) ? user.organization : null,
         created_by: [USER_TYPE.REGULAR, USER_TYPE.PUBLIC].includes(user.userType) ? 'me' : null,
     }
 
@@ -38,7 +38,7 @@ async function makeFilteredImageRequest(user = {}, pageSize, pageNumber = null, 
         page_size: pageSize,
         page: pageNumber,
         image_text: filteredName,
-        publisher: user.organization && user.userType === constants.USER_TYPE.ADMIN ? user.organization : null,
+        publisher: user.organization && [USER_TYPE.REGULAR, USER_TYPE.PUBLIC, USER_TYPE.ADMIN].includes(user.userType) ? user.organization : null,
         created_by: [USER_TYPE.REGULAR, USER_TYPE.PUBLIC].includes(user.userType) ? 'me' : null,
     }
     const result = await client.get('image', params);


### PR DESCRIPTION
#  Fixed user permissions with image requests.

-----------------------------------------------------------------------------------------------
### Breakdown:

#### Changes
1. src\actions\userImages.js
    * Changed logic of what **"publisher"** -param takes on image requests. Now instead of returning null for public- & regular users, we return organization specific images with param "created_by"
