### PR TITLE
Super admin user support

### DIFF
--- a/src/actions/user.js
+++ b/src/actions/user.js
@@ -34,6 +34,9 @@ export function loadingUser(data) {
 }
 
 const getUserType = (permissions) => {
+    if (permissions.includes(USER_TYPE.SUPERADMIN)) {
+        return USER_TYPE.SUPERADMIN
+    }
     if (permissions.includes(USER_TYPE.ADMIN)) {
         return USER_TYPE.ADMIN
     }
@@ -63,6 +66,9 @@ export const fetchUser = (id) => async (dispatch) => {
         }
         if (get(userData, 'public_memberships', []).length > 0) {
             permissions.push(USER_TYPE.PUBLIC)
+        }
+        if (get(userData, 'is_superuser', false)) {
+            permissions.push(USER_TYPE.SUPERADMIN)
         }
 
         // add all desired user data in an object which will be stored into redux store

--- a/src/components/EventActionButton/tests/EventActionButton.test.js
+++ b/src/components/EventActionButton/tests/EventActionButton.test.js
@@ -142,6 +142,7 @@ describe('EventActionButton', () => {
         describe('actions & disabled control', () => {
             const admin = {userType: USER_TYPE.ADMIN}
             const regular = {userType: USER_TYPE.REGULAR}
+            const superadmin = {userType: USER_TYPE.SUPERADMIN}
             function getEvents(count = 0, type = constants.SUPER_EVENT_TYPE_RECURRING) {
                 const sub_events = [];
                 for(let i = 0; i < count; i++) {
@@ -173,6 +174,18 @@ describe('EventActionButton', () => {
                     const button = wrapper.find(Button)
                     expect(button.prop('aria-disabled')).toBe(false)
                 })
+            })
+            describe('event action buttons when user is super admin', () => {
+                const event = {publication_status: PUBLICATION_STATUS.PUBLIC}
+                const actions = ['add', 'update', 'delete', 'cancel', 'edit', 'postpone']
+                test.each(actions)(
+                    '%s button should be enabled',
+                    ({action}) => {
+                        const wrapper = getWrapper({user: superadmin, event: event, action})
+                        const button = wrapper.find(Button)
+                        expect(button.prop('aria-disabled')).toBe(false)
+                    }
+                )
             })
             describe('action === update', () => {
                 const event = {publication_status: PUBLICATION_STATUS.DRAFT, super_event: {

--- a/src/components/FormFields/index.js
+++ b/src/components/FormFields/index.js
@@ -287,7 +287,10 @@ class FormFields extends React.Component {
         const maxSubEventCount = CONSTANTS.GENERATE_LIMIT.EVENT_LENGTH
         const userType = get(user, 'userType')
         const isRegularUser = userType === USER_TYPE.REGULAR
-        const organizationData = get(user, `${userType}OrganizationData`, {})
+        let organizationData = get(user, `${userType}OrganizationData`, {})
+        if (userType === USER_TYPE.SUPERADMIN) {
+            organizationData = get(user, `adminOrganizationData`, {})
+        }
         const publisherOptions = Object.keys(organizationData)
             .map(id => ({label: organizationData[id].name, value: id}))
         const subTimeDisable = this.subEventsContainTime(values['sub_events'])

--- a/src/components/Header/index.js
+++ b/src/components/Header/index.js
@@ -46,7 +46,7 @@ class HeaderBar extends React.Component {
 
         if (user) {
             const showModerationLink =
-                get(user, 'userType') === USER_TYPE.ADMIN && hasOrganizationWithRegularUsers(user);
+                [USER_TYPE.ADMIN, USER_TYPE.SUPERADMIN].includes(get(user, 'userType')) && hasOrganizationWithRegularUsers(user);
             this.setState({showModerationLink});
         }
     }
@@ -57,7 +57,7 @@ class HeaderBar extends React.Component {
 
         if (oldUser !== user) {
             const showModerationLink =
-                get(user, 'userType') === USER_TYPE.ADMIN && hasOrganizationWithRegularUsers(user);
+                [USER_TYPE.ADMIN, USER_TYPE.SUPERADMIN].includes(get(user, 'userType')) && hasOrganizationWithRegularUsers(user);
             this.setState({showModerationLink});
         }
     }

--- a/src/constants.js
+++ b/src/constants.js
@@ -195,6 +195,7 @@ const constants = {
     },
 
     USER_TYPE: {
+        SUPERADMIN: 'superadmin',
         ADMIN: 'admin',
         REGULAR: 'regular',
         PUBLIC: 'public',

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -138,6 +138,7 @@
     "events-management-description": "Browse and edit the contents published by your organization.",
     "events-management-description-regular-user": "Browse and edit your drafts and browse your published events. Published events can't be edited.",
     "events-management-description-public-user": "Browse and edit events published by you.",
+    "events-management-description-super-user": "Browse and edit all published events.",
     "events-management-no-results": "No editable events found.",
 
     "language-label.fi": "Content is in Finnish",

--- a/src/i18n/fi.json
+++ b/src/i18n/fi.json
@@ -149,6 +149,7 @@
     "events-management-description": "Selaa ja muokkaa oman organisaatiosi julkaistuja sisältöjä.",
     "events-management-description-regular-user": "Selaa ja muokkaa omia luonnoksiasi ja selaa julkaistuja tapahtumiasi. Julkaistuja tapahtumia ei voi muokata.",
     "events-management-description-public-user": "Selaa ja muokkaa julkaisemiasi tapahtumia.",
+    "events-management-description-super-user": "Selaa ja muokkaa kaikkia julkaistuja tapahtumia.",
     "events-management-no-results": "Yhtäkään muokattavaa tapahtumaa ei löytynyt.",
 
     "event-image-title": "Tapahtuman kuva*",

--- a/src/i18n/sv.json
+++ b/src/i18n/sv.json
@@ -136,6 +136,7 @@
     "events-management-description": "Bläddra i och redigera det publicerade innehållet från din organisation.",
     "events-management-description-regular-user": "Bläddra i och redigera dina utkast och bläddra i dina publicerade evenemang. Publicerade evenemang kan inte redigeras.",
     "events-management-description-public-user": "Bläddra och redigera dina publicerade evenemang.",
+    "events-management-description-super-user": "Bläddra och redigera alla publicerade evenemang.",
     "events-management-no-results": "Ingen redigerbar evenemang hittades.",
 
     "language-label.fi": "Innehåll finns på finska",

--- a/src/utils/checkEventEditability.js
+++ b/src/utils/checkEventEditability.js
@@ -18,8 +18,13 @@ export const userMayEdit = (user, event) => {
     const organizationMemberships = get(user, 'organizationMemberships')
     const publicationStatus = get(event, 'publication_status')
     const userHasOrganizations = !isNull(getOrganizationMembershipIds(user))
+    const isSuperAdmin = get(user, 'userType') === USER_TYPE.SUPERADMIN
 
     let userMayEdit = false
+
+    if (isSuperAdmin) {
+        return true
+    }
 
     // users that don't belong to any organization are not allowed to edit
     if (!userHasOrganizations) {

--- a/src/utils/user.js
+++ b/src/utils/user.js
@@ -78,7 +78,7 @@ export const getOrganizationMembershipIds = user => {
     if (!get(user, 'userType')) {
         return null
     }
-    if (user.userType === USER_TYPE.ADMIN) {
+    if ([USER_TYPE.ADMIN, USER_TYPE.SUPERADMIN].includes(user.userType)) {
         return user.adminOrganizations
     }
     if (user.userType === USER_TYPE.REGULAR) {

--- a/src/views/Editor/index.js
+++ b/src/views/Editor/index.js
@@ -314,7 +314,7 @@ export class EditorPage extends React.Component {
         const isUmbrellaEvent = get(editor, ['values', 'super_event_type']) === SUPER_EVENT_TYPE_UMBRELLA
         const isRecurringSub = get(editor, ['values', 'sub_event_type']) === SUB_EVENT_TYPE_RECURRING
         const isDraft = get(event, ['publication_status']) === PUBLICATION_STATUS.DRAFT
-        const isAdminUser = userType === USER_TYPE.ADMIN
+        const isAdminUser = [USER_TYPE.ADMIN, USER_TYPE.SUPERADMIN].includes(userType)
         const hasSubEvents = subEvents && subEvents.length > 0
         const headerTextId = editMode === 'update'
             ? 'edit-events'

--- a/src/views/Event/index.js
+++ b/src/views/Event/index.js
@@ -181,7 +181,7 @@ class EventPage extends React.Component {
         const {event, loading} = this.state
         const userType = get(user, 'userType')
         const isDraft = event.publication_status === PUBLICATION_STATUS.DRAFT
-        const isAdmin = userType === USER_TYPE.ADMIN
+        const isAdmin = [USER_TYPE.ADMIN, USER_TYPE.SUPERADMIN].includes(userType)
         const isRecurring = event.super_event_type === SUPER_EVENT_TYPE_RECURRING
         const editEventButton = this.getActionButton('edit', idPrefix,this.openEventInEditor, false)
         const addRecurringButton = this.getActionButton('add',idPrefix, () => this.openEventInEditor('addRecurring'), false)

--- a/src/views/EventListing/EventListing.test.js
+++ b/src/views/EventListing/EventListing.test.js
@@ -255,6 +255,30 @@ describe('EventListing', () => {
             });
         });
 
+        describe('getPageSubtitle', () => {
+            
+            test('gets correct eventListing page title for super admin', () => {
+                mockUser.userType = 'superadmin';
+                const wrapper = getWrapper({user: mockUser});
+                expect(wrapper.find('#events-management-description-super-user')).toHaveLength(1);
+            });
+            test('gets correct eventListing page title for regular user', () => {
+                mockUser.userType = 'regular';
+                const wrapper = getWrapper({user: mockUser});
+                expect(wrapper.find('#events-management-description-regular-user')).toHaveLength(1);
+            });
+            test('gets correct eventListing page title for public user', () => {
+                mockUser.userType = 'public';
+                const wrapper = getWrapper({user: mockUser});
+                expect(wrapper.find('#events-management-description-public-user')).toHaveLength(1);
+            });
+            test('gets correct eventListing page title for admin', () => {
+                mockUser.userType = 'admin';
+                const wrapper = getWrapper({user: mockUser});
+                expect(wrapper.find('#events-management-description')).toHaveLength(1);
+            });
+        });
+
         describe('toggleEventLanguages', () => {
             const event = (lang) => ({target: {value: lang}});
             describe('sets values to state', () => {

--- a/src/views/EventListing/__snapshots__/EventListing.test.js.snap
+++ b/src/views/EventListing/__snapshots__/EventListing.test.js.snap
@@ -500,6 +500,7 @@ exports[`EventListing Snapshot should render view correctly 1`] = `
       "events-management-description": "Selaa ja muokkaa oman organisaatiosi julkaistuja sisältöjä.",
       "events-management-description-public-user": "Selaa ja muokkaa julkaisemiasi tapahtumia.",
       "events-management-description-regular-user": "Selaa ja muokkaa omia luonnoksiasi ja selaa julkaistuja tapahtumiasi. Julkaistuja tapahtumia ei voi muokata.",
+      "events-management-description-super-user": "Selaa ja muokkaa kaikkia julkaistuja tapahtumia.",
       "events-management-no-results": "Yhtäkään muokattavaa tapahtumaa ei löytynyt.",
       "events-management-prompt": "muokataksesi sisältöä.",
       "events-management-tip": "Suodatuksen asetukset",

--- a/src/views/EventListing/index.js
+++ b/src/views/EventListing/index.js
@@ -319,6 +319,21 @@ export class EventListing extends React.Component {
         });
     };
 
+    getPageSubtitle = () => {
+        const {user} = this.props;
+
+        if (get(user, 'userType') === USER_TYPE.SUPERADMIN) {
+            return <FormattedMessage id="events-management-description-super-user" />
+        }
+        if (get(user, 'userType') === USER_TYPE.REGULAR) {
+            return <FormattedMessage id="events-management-description-regular-user" />
+        }
+        if (get(user, 'userType') === USER_TYPE.PUBLIC) {
+            return <FormattedMessage id="events-management-description-public-user" />
+        }
+        return <FormattedMessage id="events-management-description" />
+    }
+
     render() {
         const {user} = this.props;
         const {intl} = this.context;
@@ -338,6 +353,7 @@ export class EventListing extends React.Component {
         const header = <h1><FormattedMessage id={`${appSettings.ui_mode}-management`}/></h1>
         // Defined React Helmet title with intl
         const pageTitle = `Linkedevents - ${intl.formatMessage({id: `${appSettings.ui_mode}-management`})}`
+        const pageSubtitle = this.getPageSubtitle()
         const isRegularUser = get(user, 'userType') === USER_TYPE.REGULAR
         const isPublicUser = get(user, 'userType') === USER_TYPE.PUBLIC
 
@@ -357,19 +373,9 @@ export class EventListing extends React.Component {
             <div className="container">
                 <Helmet title={pageTitle} />
                 {header}
-                {isPublicUser
-                    ?
-                    <p>
-                        <FormattedMessage id="events-management-description-public-user"/>
-                    </p>
-                    :
-                    <p>
-                        {isRegularUser
-                            ? <FormattedMessage id="events-management-description-regular-user"/>
-                            : <FormattedMessage id="events-management-description"/>
-                        }
-                    </p>
-                }
+                <p>
+                    {pageSubtitle}
+                </p>
                 {!isRegularUser &&
                 <div className='event-settings'>
                     <h2>

--- a/src/views/Search/__snapshots__/Search.test.js.snap
+++ b/src/views/Search/__snapshots__/Search.test.js.snap
@@ -299,6 +299,7 @@ exports[`Search Snapshot should render view correctly 1`] = `
       "events-management-description": "Selaa ja muokkaa oman organisaatiosi julkaistuja sisältöjä.",
       "events-management-description-public-user": "Selaa ja muokkaa julkaisemiasi tapahtumia.",
       "events-management-description-regular-user": "Selaa ja muokkaa omia luonnoksiasi ja selaa julkaistuja tapahtumiasi. Julkaistuja tapahtumia ei voi muokata.",
+      "events-management-description-super-user": "Selaa ja muokkaa kaikkia julkaistuja tapahtumia.",
       "events-management-no-results": "Yhtäkään muokattavaa tapahtumaa ei löytynyt.",
       "events-management-prompt": "muokataksesi sisältöä.",
       "events-management-tip": "Suodatuksen asetukset",


### PR DESCRIPTION
# Super admin user support

## Changes

- Add a new user type `SUPERADMIN`
- Super admins can:
    - See all editable events in the "Manage Content" view ([Trello #374](https://trello.com/c/NTxmHZYV/374-frontend-list-all-events-for-super-admin-users))
    - Perform any action on an event ([Trello #373](https://trello.com/c/srxKjMX9/373-frontend-super-admin-action-permissions-events))

### [Trello card #373](https://trello.com/c/srxKjMX9/373-frontend-super-admin-action-permissions-events), [Trello card #374](https://trello.com/c/NTxmHZYV/374-frontend-list-all-events-for-super-admin-users)

-----------------------------------------------------------------------------------------------
### Breakdown:

 1. src/constants.js 
     * Add new user type `USER_TYPE.SUPERADMIN`
   
 2. src/actions/user.js
     * Utilize the `is_superuser` flag for determining if a user is a super admin and set the permissions accordingly

 3. src/views/EventListing/index.js
     * Change the text in the Manage Content view for super admins
     
 4. src/components/Header/index.js 
     * Make sure the "Moderate Content" view is still accessible for super admins if they are also organization admins

 5. src/components/FormFields/index.js
      * Handle organization memberships for super admins.
   
 6. src/utils/checkEventEditability.js
     * Allow super admins to edit all events
    
 7. src/utils/user.js
      * Make sure that super admins can still select the organizations where they are an organization admin.

 8. src/views/Editor/index.js
      * Make sure the "Validate form" button is visible for super admins in the event form