### PR TITLE
Feature/fix linting issues

### DIFF
--- a/src/components/ValidationNotification/index.js
+++ b/src/components/ValidationNotification/index.js
@@ -49,7 +49,7 @@ const ValidationNotification =  ({
                 ? <p
                     id={id}
                     className={className}
-                    anchor={anchor}>
+                >
                     { errorMsg }
                 </p>
                 : <React.Fragment />

--- a/src/views/Notification/index.js
+++ b/src/views/Notification/index.js
@@ -80,12 +80,12 @@ class Notifications extends React.Component {
         return (
             <React.Fragment>
                 { flashMsgSpan &&
-                    <div className='notification'
+                    <dialog className='notification'
                         open={(!!flashMsg)}
                         onClose={closeFn}
                     >
                         <p className="text-center" role='alert'>{flashMsgSpan}{[actionButton]}</p>
-                    </div>
+                    </dialog>
                 }
             </React.Fragment>
         )

--- a/src/views/Notification/index.scss
+++ b/src/views/Notification/index.scss
@@ -3,7 +3,8 @@
     position: fixed;
     bottom: 0;
     z-index: 100;
-    padding-top: 1rem;
+    padding: 1rem 0 0 0;
+    border: none;
     color: #ffff;
     background-color: #222222;
     min-width: -webkit-fill-available;

--- a/src/views/Notification/tests/Notifications.test.js
+++ b/src/views/Notification/tests/Notifications.test.js
@@ -25,13 +25,13 @@ describe('Notifications', () => {
     }
 
     describe('when flash message is defined', () => {
-        test('renders div', () => {
+        test('renders dialog', () => {
             const isSticky =  flashMsg && flashMsg.sticky
             const duration = isSticky ? null : 7000
-            const div = getWrapper({flashMsg}).find('div')
-            expect(div).toHaveLength(1)
-            expect(div.prop('open')).toBe(!!flashMsg)
-            expect(div.prop('onClose')).toBeDefined()
+            const dialog = getWrapper({flashMsg}).find('dialog')
+            expect(dialog).toHaveLength(1)
+            expect(dialog.prop('open')).toBe(!!flashMsg)
+            expect(dialog.prop('onClose')).toBeDefined()
         })
 
         test('renders paragraph', () => {
@@ -44,9 +44,9 @@ describe('Notifications', () => {
     })
 
     describe('when flash message is not defined', () => {
-        test('doesnt render div', () => {
-            const div = getWrapper().find('div')
-            expect(div).toHaveLength(0)
+        test('doesnt render dialog', () => {
+            const dialog = getWrapper().find('dialog')
+            expect(dialog).toHaveLength(0)
         })
 
         test('doesnt render paragraph', () => {


### PR DESCRIPTION
# Fix linting issues

## Fix linting issues that caused frontend build to fail

### [Trello card #377](https://trello.com/c/i0T6b7UR/377-frontend-fix-the-linting-issues-causing-the-build-to-fail)

-----------------------------------------------------------------------------------------------
### Breakdown:

 1. src/components/ValidationNotification/index.js
     * remove unused anchor attribute
   
 2. src/views/Notification/index.js
     * render Notification as dialog instead of div to support onClose event
