### PR TITLE
Pin sanitize-html version

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "redux-actions": "^2.6.5",
     "redux-oidc": "^4.0.0-beta1",
     "redux-thunk": "^2.3.0",
-    "sanitize-html": "^2.7.0",
+    "sanitize-html": ">=2.7.0 <2.8.0",
     "sass": "^1.28.0",
     "typeahead.js": "^0.11.1"
   },


### PR DESCRIPTION
 # Pin sanitize-html version

## 2.8.0 version of the sanitize-html broke the build, so pin the version to 2.7.x


-----------------------------------------------------------------------------------------------
### Breakdown:
 1. package.json 
     * pins sanitize-html to version 2.7.x
   
 
