### PR TITLE
Manage content: Add filtering content by name or place

### DIFF
--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -11,6 +11,7 @@
     "event-search": "Search",
     "event-name-or-place": "Content name or place",
     "event-type-select": "Choose content type",
+    "event-filter-content-text": "Filter by content name, description or place:",
     "search-event-button": "Search for contents",
     "lang-fi": "Finnish",
     "lang-en": "English",

--- a/src/i18n/fi.json
+++ b/src/i18n/fi.json
@@ -11,6 +11,7 @@
     "event-search": "Hae",
     "event-name-or-place": "Sisällön nimi tai paikka",
     "event-type-select": "Valitse sisällön tyyppi",
+    "event-filter-content-text": "Suodata nimen, sisällön tai paikan mukaan:",
     "search-event-button": "Hae sisältöjä",
     "lang-fi": "Suomi",
     "lang-en": "Englanti",

--- a/src/i18n/sv.json
+++ b/src/i18n/sv.json
@@ -11,6 +11,7 @@
     "event-search": "Sök",
     "event-name-or-place": "Innehållets namn och plats",
     "event-type-select": "Välj innehållets typ",
+    "event-filter-content-text": "Filtrera efter namn, beskrivning eller plats:",
     "search-event-button": "Sök innehåll",
     "lang-fi": "Finska",
     "lang-en": "Engelska",

--- a/src/views/EventListing/EventListing.test.js
+++ b/src/views/EventListing/EventListing.test.js
@@ -215,7 +215,7 @@ describe('EventListing', () => {
             test('correct amount', () => {
                 const wrapper = getWrapper();
                 const formattedMessages = wrapper.find(FormattedMessage);
-                expect(formattedMessages).toHaveLength(5);
+                expect(formattedMessages).toHaveLength(6);
             })
         })
         describe('selectorRadios', () => {
@@ -289,8 +289,12 @@ describe('EventListing', () => {
             const MultiLevelSelectElement = wrapper.find(MultiLevelSelect)
             expect(MultiLevelSelectElement).toHaveLength(0)
         })
-        
-        
+
+        test('Text filter input element should exist', () => {
+            const wrapper = getWrapper();
+            const inputElement = wrapper.find('#search')
+            expect(inputElement).toHaveLength(1)
+        })
     })
 
     describe('methods', () => {
@@ -469,6 +473,26 @@ describe('EventListing', () => {
                 expect(wrapper.state('selectedPublishers')).toHaveLength(0);
                 await instance.handleOrganizationValueChange(_,['yso:1200','turku:853'])
                 expect(wrapper.state('selectedPublishers')).toHaveLength(2);
+            });
+        });
+        
+        describe('handleTextQueryChange', () => {
+            test('changes textSearchQuery ', async () => {
+                const wrapper = getWrapper();
+                const instance = wrapper.instance();
+                expect(wrapper.state('textSearchQuery')).toHaveLength(0);
+                const event = {target: {value: 'hello'}}
+                await instance.handleTextQueryChange(event)
+                expect(wrapper.state('textSearchQuery')).toBe(event.target.value)
+            });
+            test('adds textSearchQuery to the query params', async () => {
+                const wrapper = getWrapper();
+                const instance = wrapper.instance();
+                expect(wrapper.state('textSearchQuery')).toHaveLength(0);
+                const event = {target: {value: 'hello'}}
+                await instance.handleTextQueryChange(event)
+                const queryParams = await instance.getDefaultEventQueryParams()
+                expect(queryParams.text).toBe(wrapper.state('textSearchQuery'))
             });
         });
 

--- a/src/views/EventListing/__snapshots__/EventListing.test.js.snap
+++ b/src/views/EventListing/__snapshots__/EventListing.test.js.snap
@@ -281,6 +281,41 @@ exports[`EventListing Snapshot should render view by default 1`] = `
             </div>
           </fieldset>
         </fieldset>
+        <fieldset>
+          <FormGroup
+            tag="div"
+          >
+            <Label
+              htmlFor="search"
+              tag="label"
+              widths={
+                Array [
+                  "xs",
+                  "sm",
+                  "md",
+                  "lg",
+                  "xl",
+                ]
+              }
+            >
+              <FormattedMessage
+                id="event-filter-content-text"
+                values={Object {}}
+              >
+                <Component />
+              </FormattedMessage>
+            </Label>
+            <Input
+              aria-label="Hae Suodata nimen, sisällön tai paikan mukaan:"
+              className="text-search-input"
+              id="search"
+              onBlur={[Function]}
+              onChange={[Function]}
+              type="text"
+              value=""
+            />
+          </FormGroup>
+        </fieldset>
       </div>
       <hr
         style={
@@ -560,6 +595,7 @@ exports[`EventListing Snapshot should render view correctly 1`] = `
       "event-enrolment-start-time": "Ilmoittautuminen alkaa (pp.kk.vvvv)",
       "event-enrolment-time": "Ilmoittautumisaika",
       "event-enrolment-url": "Linkki ilmoittautumiseen",
+      "event-filter-content-text": "Suodata nimen, sisällön tai paikan mukaan:",
       "event-form-header": "Syötä ilmoittautumistiedot",
       "event-has-umbrella": "Liittyy kattotapahtumaan",
       "event-has-umbrella-select-tip": "Huom. Kattotapahtuma täytyy luoda ennen kuin voit lisätä sille alatapahtumia.",

--- a/src/views/EventListing/index.js
+++ b/src/views/EventListing/index.js
@@ -11,7 +11,7 @@ import EventTable from '../../components/EventTable/EventTable'
 import {getOrganizationMembershipIds} from '../../utils/user'
 import userManager from '../../utils/userManager';
 import {Helmet} from 'react-helmet';
-import {Collapse} from 'reactstrap';
+import {Collapse, FormGroup, Form, Input, Label} from 'reactstrap';
 import CollapseButton from '../../components/FormFields/CollapseButton/CollapseButton';
 import SelectorRadio from '../../components/HelFormFields/Selectors/SelectorRadio';
 import HelCheckbox from '../../components/HelFormFields/HelCheckbox';
@@ -40,6 +40,7 @@ export class EventListing extends React.Component {
                 sortDirection: 'desc',
             },
             selectedPublishers: [],
+            textSearchQuery: '',
         };
     }
 
@@ -317,6 +318,9 @@ export class EventListing extends React.Component {
         if (this.state.showContentLanguage) {
             queryParams.language = this.state.showContentLanguage
         }
+        if (this.state.textSearchQuery){
+            queryParams.text = this.state.textSearchQuery
+        }
         return queryParams
     }
 
@@ -370,6 +374,32 @@ export class EventListing extends React.Component {
                         ...state.tableData,
                         events: response.data.data,
                         count: response.data.meta.count,
+                    },
+                }))
+            } finally {
+                this.setLoading(true)
+            }
+        }
+    }
+
+    handleTextQueryChange = async (event) => {
+        const value = (event.target.value).trim();
+        if(this.state.textSearchQuery !== value){
+            this.setState(()=>({textSearchQuery: value}))
+
+            const queryParams = this.getDefaultEventQueryParams()
+            queryParams.text = value;
+
+            this.setLoading(false)
+            try {
+                const response = await fetchEvents(queryParams)
+
+                this.setState(state => ({
+                    tableData: {
+                        ...state.tableData,
+                        events: response.data.data,
+                        count: response.data.meta.count,
+                        paginationPage: 0,
                     },
                 }))
             } finally {
@@ -524,6 +554,22 @@ export class EventListing extends React.Component {
                                         </SelectorRadio>
                                     </div>
                                 </fieldset>
+                            </fieldset>
+                            <fieldset>
+                                <FormGroup>
+                                    <Label htmlFor='search'>
+                                        <FormattedMessage id='event-filter-content-text'>{txt => <legend>{txt}</legend>}</FormattedMessage>
+                                    </Label>
+                                    <Input
+                                        aria-label={intl.formatMessage({id: 'event-search'}) + ' ' + intl.formatMessage({id: 'event-filter-content-text'})}
+                                        id='search'
+                                        className='text-search-input'
+                                        type='text'
+                                        onChange={this.handleTextQueryChange}
+                                        onBlur={this.handleTextQueryChange}
+                                        value={this.state.textSearchQuery}
+                                    />
+                                </FormGroup>
                             </fieldset>
                         </div>
                         <hr style={{borderTop: '2px solid black'}}/>

--- a/src/views/EventListing/index.scss
+++ b/src/views/EventListing/index.scss
@@ -26,6 +26,18 @@
             padding-left: 0;
         }
     }
+    .text-search-input {
+            border: 2px solid var(--black-color) !important;
+            width: auto;
+            border-radius: 3px;
+            &:hover,
+            &:focus,
+            &:active {
+                box-shadow: none !important;
+                border-color: var(--main-color) !important;
+            }
+        }
+    
 }
 .filter-mobile {
     display: none;

--- a/src/views/Search/__snapshots__/Search.test.js.snap
+++ b/src/views/Search/__snapshots__/Search.test.js.snap
@@ -252,6 +252,7 @@ exports[`Search Snapshot should render view correctly 1`] = `
       "event-enrolment-start-time": "Ilmoittautuminen alkaa (pp.kk.vvvv)",
       "event-enrolment-time": "Ilmoittautumisaika",
       "event-enrolment-url": "Linkki ilmoittautumiseen",
+      "event-filter-content-text": "Suodata nimen, sisällön tai paikan mukaan:",
       "event-form-header": "Syötä ilmoittautumistiedot",
       "event-has-umbrella": "Liittyy kattotapahtumaan",
       "event-has-umbrella-select-tip": "Huom. Kattotapahtuma täytyy luoda ennen kuin voit lisätä sille alatapahtumia.",


### PR DESCRIPTION
 # Manage content: Add filtering content by name or place

## Changes
      - adds text input field to manage content page for filtering content by name or place

### [Trello ticket #387](https://trello.com/c/Vmlm9p3F/387-manage-content-searching-by-content-name)

-----------------------------------------------------------------------------------------------
### Breakdown:

 1. src/views/EventListing/EventListing.test.js
     * adds text filtering related test to EventListing
   
 2. src/views/EventListing/__snapshots__/EventListing.test.js.snap
     * updates EventListing snapshots with text field related changes
    
 3. src/views/EventListing/index.js
     * adds text input field for filtering content by name or place
     
 4. src/views/EventListing/index.scss
     * adds styling related to text input field
   
 5. src/views/Search/__snapshots__/Search.test.js.snap
     * updates Search snapshots with text field related changes
    
