### PR TITLE
Remove opacity near me checkbox

### DIFF
--- a/src/views/Search/index.scss
+++ b/src/views/Search/index.scss
@@ -21,7 +21,6 @@
 
 .custom-control.custom-checkbox .custom-control-input:checked ~ .custom-control-label::before {
     background-color: var(--main-color);
-    opacity: 0.7;
 }
 .custom-checkbox .custom-control-input:checked ~ .custom-control-label::after {
     cursor: pointer;


### PR DESCRIPTION
# Remove opacity from near me checkbox

## changes
   - removes opacity from near me checkbox

### [Trello card #371](https://trello.com/c/6EwJyY0B/371-k%C3%A4ytt%C3%A4j%C3%A4-n%C3%A4kee-h%C3%A4nt%C3%A4-l%C3%A4hell%C3%A4-olevat-tapahtumat-harrastukset-koulutukset)

-----------------------------------------------------------------------------------------------
### Breakdown:

 1. src/views/Search/index.scss
     * removes opacity from styling 
   
 
