### PR TITLE
Check and re-set state when page is refreshed

### DIFF
--- a/src/views/Editor/Editor.test.js
+++ b/src/views/Editor/Editor.test.js
@@ -39,6 +39,9 @@ const initialStoreExistingEvent = {
     editor: mockEditorExistingEvent,
 };
 
+const mockRegularUser = JSON.parse(JSON.stringify(mockUser));
+mockRegularUser.userType = 'regular';
+
 describe('Editor Snapshot', () => {
     it('should render view correctly when new event', () => {
         const componentProps = {
@@ -168,6 +171,16 @@ describe('Editor Snapshot', () => {
                 getWrapper(props);
                 const expectedValues = ['user-no-rights-create', 'error', {sticky: true}];
                 expect(props.setFlashMsg).toHaveBeenCalledWith(...expectedValues);
+            });
+        });
+        describe('componentDidUpdate', () => {
+            test('isRegularUser is set when component updates', () => {
+                const wrapper = getWrapper({user: mockRegularUser});
+                const instance = wrapper.instance();
+                const prevProps = {...instance.props}
+                const prevState = {...instance.state, isRegularUser: false}
+                instance.componentDidUpdate(prevProps, prevState);
+                expect(instance.state.isRegularUser).toBe(true)
             });
         });
     });

--- a/src/views/Editor/index.js
+++ b/src/views/Editor/index.js
@@ -76,13 +76,17 @@ export class EditorPage extends React.Component {
     }
 
     componentDidUpdate(prevProps, prevState) {
-        const {event} = this.state
-
+        const {event, isRegularUser} = this.state
+        const {user} = this.props
         const publisherId = get(event, 'publisher')
         const oldPublisherId = get(prevState, ['event', 'publisher'])
         const prevParams = get(prevProps, ['match', 'params'], {})
         const currParams = get(this.props, ['match', 'params'], {})
-
+        const currentIsRegularUser = get(user, 'userType') === USER_TYPE.REGULAR
+        // check and re-set isRegularUser state
+        if(currentIsRegularUser !== isRegularUser){
+            this.setState({isRegularUser: currentIsRegularUser});
+        }
         // check if the editing mode or if the eventId params changed
         if (prevParams.action !== currParams.action || prevParams.eventId !== currParams.eventId) {
             if (currParams.action === 'update') {


### PR DESCRIPTION
 # Check and re-set state when page is refreshed

## changes
    - re-sets `isRegularUser` state at Editor page when component updates

### [Trello card #390](https://trello.com/c/NGczgWvL/390-bug-refreshing-page-on-create-content-tab-clears-the-user-data)

-----------------------------------------------------------------------------------------------
### Breakdown:

 1. src/views/Editor/index.js
     * checks and re-sets `isRegularUser` state on component update
     
 2. src/views/Editor/Editor.test.js
     * adds test
   
 
