### PR TITLE
Admin panel: display parent organization

### DIFF
--- a/src/components/AdminFields/Organizations/OrganizationPermissions/OrganizationEditor.js
+++ b/src/components/AdminFields/Organizations/OrganizationPermissions/OrganizationEditor.js
@@ -81,6 +81,7 @@ class OrganizationEditor extends React.Component {
         const values = ['name', 'data_source', 'classification', 'internal_type', 'origin_id']
         const useValue = values.includes(name);
         let newValue = e;
+        if(name === 'parent_organization') {newValue = e['@id']}
         if (useValue) {newValue = newValue.target.value}
         if (name === 'founding_date') { newValue = moment(e).tz('Europe/Helsinki').utc(e, 'YYYY-MM-DD').format('YYYY-MM-DD')}
         this.setState({
@@ -145,7 +146,7 @@ class OrganizationEditor extends React.Component {
     }
 
     render() {
-        const {orgMode, intl} = this.props;
+        const {orgMode, intl, organizations} = this.props;
         const {organizationData, errors} = this.state;
 
         return (
@@ -236,8 +237,14 @@ class OrganizationEditor extends React.Component {
                     />
                 </div>
                 <div className='value-row'>
-                    <OrganizationSelect label={intl.formatMessage({id: 'admin-org-child'})} disabled={this.setDisabled()} name='parent_organization'
-                        getSelectedOrg={(e) => this.onChange('parent_organization', e)} selectedValue={organizationData.parent_organization}/>
+                    <OrganizationSelect 
+                        label={intl.formatMessage({id: 'admin-org-child'})} 
+                        disabled={this.setDisabled()} 
+                        name='parent_organization'
+                        getSelectedOrg={(e) => this.onChange('parent_organization', e)} 
+                        selectedValue={organizationData.parent_organization}
+                        organizations={organizations}
+                    />
                 </div>
                 <div className='button-controls'>
                     <Button disabled={errors} onClick={() => this.dispatchData()}>{intl.formatMessage({id: 'admin-org-save'})}</Button>
@@ -255,10 +262,15 @@ OrganizationEditor.propTypes = {
     executeSendRequestOrg: PropTypes.func,
     mode: PropTypes.string,
     orgMode: PropTypes.func,
+    organizations: PropTypes.array,
 }
 
+const mapStateToProps = (state) => ({
+    organizations: state.organizations.data,
+})
 const mapDispatchToProps = (dispatch) => ({
     executeSendRequestOrg: (orgValues, updatingOrganization) => dispatch(executeSendRequestOrgAction(orgValues, updatingOrganization)),
 })
 
-export default connect(null, mapDispatchToProps)(injectIntl(OrganizationEditor))
+export {OrganizationEditor as UnconnectedOrganizationEditor}
+export default connect(mapStateToProps, mapDispatchToProps)(injectIntl(OrganizationEditor))

--- a/src/components/AdminFields/Organizations/OrganizationPermissions/OrganizationEditor.test.js
+++ b/src/components/AdminFields/Organizations/OrganizationPermissions/OrganizationEditor.test.js
@@ -1,0 +1,61 @@
+import React from 'react'
+import {shallow} from 'enzyme';
+import {IntlProvider, FormattedMessage} from 'react-intl';
+import mapValues from 'lodash/mapValues';
+import fiMessages from 'src/i18n/fi.json';
+import {mockOrganizations} from '../../../../../__mocks__/mockData';
+import OrganizationSelect from '../../utils/OrganizationSelect';
+
+const testMessages = mapValues(fiMessages, (value, key) => value);
+const intlProvider = new IntlProvider({locale: 'fi', messages: testMessages}, {});
+const {intl} = intlProvider.getChildContext();
+import {UnconnectedOrganizationEditor} from './OrganizationEditor';
+
+const organizationData = {
+    classification: 'org:3',
+    data_source: 'turku',
+    founding_date: null,
+    id: 'turku:4032',
+    internal_type: undefined,
+    name: 'Ammatillinen koulutus',
+    parent_organization: 'http://localhost:8006/v1/organization/turku:40/',
+}
+
+const defaultProps = {
+    intl: intl,
+    organization: {},
+    executeSendRequestOrg: jest.fn(),
+    mode: 'edit',
+    orgMode: jest.fn(),
+    organizations: mockOrganizations,
+}
+
+function getWrapper(props) {
+    return shallow(<UnconnectedOrganizationEditor {...defaultProps} {...props} />, {context: {intl}});
+}
+
+describe('renders', () => {
+    describe('element', () => {
+        test('dev containing organization-form', () => {
+            const wrapper = getWrapper();
+            const div = wrapper.find('.organization-form');
+            expect(div).toHaveLength(1);
+        })
+        test('OrganizationSelect', () => {
+            const wrapper = getWrapper();
+            const organizationSelect = wrapper.find(OrganizationSelect);
+            expect(organizationSelect).toHaveLength(1);
+        })
+        test('OrganizationSelect with correct props', () => {
+            const wrapper = getWrapper();
+            const instance = wrapper.instance();
+            instance.setState({organizationData, errors: false})
+            const organizationSelect = wrapper.find(OrganizationSelect);
+            expect(organizationSelect.prop('organizations')).toBe(defaultProps.organizations);
+            expect(organizationSelect.prop('label')).toBe(intl.formatMessage({id: 'admin-org-child'}));
+            expect(organizationSelect.prop('name')).toBe('parent_organization');
+            expect(organizationSelect.prop('selectedValue')).toBe(organizationData.parent_organization);
+            expect(organizationSelect.prop('getSelectedOrg')).toBeDefined();
+        })
+    })
+})

--- a/src/components/AdminFields/utils/OrganizationSelect.js
+++ b/src/components/AdminFields/utils/OrganizationSelect.js
@@ -87,7 +87,7 @@ class OrganizationSelect extends React.Component {
      * @returns {{name,value}|null}
      */
     getDefaultValue = () => {
-        const {selectedValue, name} = this.props;
+        const {selectedValue, name, organizations} = this.props;
         if (!selectedValue) {
             return null
         }
@@ -95,6 +95,15 @@ class OrganizationSelect extends React.Component {
             return ({
                 name: selectedValue,
                 value: selectedValue,
+            })
+        }
+        if(name === 'parent_organization'){
+            const orgId = selectedValue.split('/').findLast((item)=> item !== ''),
+                organization = organizations.find((org) => org.id === orgId)
+
+            return({
+                name: organization.name,
+                value: organization['@id'],
             })
         }
         return ({
@@ -156,6 +165,7 @@ OrganizationSelect.propTypes = {
     disabled: PropTypes.bool,
     getSelectedOrg: PropTypes.func,
     label: PropTypes.string,
+    organizations: PropTypes.array,
 }
-
+export {OrganizationSelect as UnconnectedOrganizationSelect}
 export default injectIntl(OrganizationSelect)

--- a/src/components/AdminFields/utils/tests/OrganizationSelect.test.js
+++ b/src/components/AdminFields/utils/tests/OrganizationSelect.test.js
@@ -1,0 +1,54 @@
+import React from 'react'
+import {shallow} from 'enzyme';
+import {IntlProvider, FormattedMessage} from 'react-intl';
+import mapValues from 'lodash/mapValues';
+import fiMessages from 'src/i18n/fi.json';
+import {UnconnectedOrganizationSelect} from '../OrganizationSelect';
+import {mockUser, mockOrganizations} from '../../../../../__mocks__/mockData';
+import AsyncSelect from 'react-select/async';
+
+const testMessages = mapValues(fiMessages, (value, key) => value);
+const intlProvider = new IntlProvider({locale: 'fi', messages: testMessages}, {});
+const {intl} = intlProvider.getChildContext();
+const mockSuperAdminUser = JSON.parse(JSON.stringify(mockUser));
+mockSuperAdminUser.userType = 'superadmin';
+
+const defaultProps = {
+    intl,
+    user: mockSuperAdminUser,
+    admin: {},
+    selectedValue: 'http://localhost:8006/v1/organization/turku:40/',
+    name: 'parent_organization',
+    disabled: false,
+    getSelectedOrg: jest.fn(),
+    label: 'test-id',
+    organizations: mockOrganizations,
+}
+
+
+function getWrapper(props) {
+    return shallow(<UnconnectedOrganizationSelect {...defaultProps} {...props} />, {intl: {intl}});
+}
+
+describe('UnconnectedOrganizationSelect', () => {
+
+    describe('Components', () => {
+        describe('AsyncSelect', () => {
+            const wrapper = getWrapper()
+            test('correct props', () => {
+                const orgId = defaultProps.selectedValue.split('/').findLast((item)=> item !== ''),
+                    organization = defaultProps.organizations.find((org) => org.id === orgId)
+                const asyncSelect = wrapper.find(AsyncSelect)
+                expect(asyncSelect.prop('value')).toMatchObject({name: organization.name, value: organization['@id']})
+                expect(asyncSelect.prop('classNamePrefix')).toBe('user-search')
+                expect(asyncSelect.prop('inputId')).toBe('select')
+                expect(asyncSelect.prop('isDisabled')).toBe(defaultProps.disabled)
+                expect(asyncSelect.prop('defaultOptions')).toBe(true)
+                expect(asyncSelect.prop('isClearable')).toBe(false)
+                expect(asyncSelect.prop('onChange')).toBeDefined()
+                expect(asyncSelect.prop('loadOptions')).toBeDefined()
+                expect(asyncSelect.prop('formatOptionLabel')).toBeDefined()
+            })
+        })
+    })
+})

--- a/src/views/Admin/Admin.test.js
+++ b/src/views/Admin/Admin.test.js
@@ -13,7 +13,7 @@ import CONSTANTS from '../../constants'
 import EventDetails from '../../components/EventDetails';
 import {mapAPIDataToUIFormat} from '../../utils/formDataMapping';
 import Users from '../../components/AdminFields/User';
-
+import  Organizations from '../../components/AdminFields/Organizations'
 const testMessages = mapValues(fiMessages, (value, key) => value);
 const intlProvider = new IntlProvider({locale: 'fi', messages: testMessages}, {});
 const {intl} = intlProvider.getChildContext();
@@ -133,11 +133,18 @@ describe('AdminPanel', () => {
         })
 
         describe('getComponent', () => {
-            test('returns correct component', () => {
+            test('returns Users component', () => {
                 const wrapper = getWrapper()
                 const instance = wrapper.instance()
                 const component = instance.getComponent('users')
                 expect(component).toStrictEqual(<Users intl={defaultProps.intl} />)
+            })
+
+            test('returns Organizations component', () => {
+                const wrapper = getWrapper()
+                const instance = wrapper.instance()
+                const component = instance.getComponent('organizations')
+                expect(component).toStrictEqual(<Organizations intl={defaultProps.intl} />)
             })
         })
     });


### PR DESCRIPTION
 

# Display parent organization

## changes
     - displays parent organization in admin panel select
     
### [Trello card #395](https://trello.com/c/kEBeiOb4/395-bug-while-editing-organization-with-parent-organization-backend-returns-only-string-pointing-to-parent-organization-which-is-not)

-----------------------------------------------------------------------------------------------
### Breakdown:

 1. src/components/AdminFields/Organizations/OrganizationPermissions/OrganizationEditor.js
     * passes organizations prop to OrganizationSelect
   
 2. src/components/AdminFields/Organizations/OrganizationPermissions/OrganizationEditor.test.js
     * adds tests
    
 3. src/components/AdminFields/utils/OrganizationSelect.js
     * gets correct parent organization
     
 4. src/components/AdminFields/utils/tests/OrganizationSelect.test.js
     * adds tests
   
 5. src/views/Admin/Admin.test.js
     * adds tests
    
