### PR TITLE
Event search: Allow selecting max distance to events

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -256,6 +256,8 @@ const constants = {
     LOCATION_OPTIONS: {
         enableHighAccuracy: true, // get possible accurate location
     },
+
+    DEFAULT_SEARCH_DISTANCE: 5,  // in kilometers
 }
 
 export default constants

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -8,6 +8,8 @@
     "no-events": "No contents to show.",
     "search-events-description": "View all contents on Linked Events.",
     "search-events-near-me": "Show contents near me",
+    "search-events-max-distance": "Search radius:",
+    "search-events-max-distance-aria-label": "Search radius in kilometers",
     "pick-time-range": "Pick time range",
     "event-search": "Search",
     "event-name-or-place": "Content name or place",

--- a/src/i18n/fi.json
+++ b/src/i18n/fi.json
@@ -8,6 +8,8 @@
     "no-events": "Ei sisältöjä, joita näyttää.",
     "search-events-description": "Katsele kaikkia Linked Eventsin sisältöjä.",
     "search-events-near-me": "Näytä lähellä olevat sisällöt",
+    "search-events-max-distance": "Etäisyys enintään:",
+    "search-events-max-distance-aria-label": "Etäisyys enintään kilometreissä",
     "pick-time-range": "Etsi vain ajalta",
     "event-search": "Hae",
     "event-name-or-place": "Sisällön nimi tai paikka",

--- a/src/i18n/sv.json
+++ b/src/i18n/sv.json
@@ -8,6 +8,8 @@
     "no-events": "Inget innehåll att visa.",
     "search-events-description": "Se alla innehåll i Linked Events.",
     "search-events-near-me": "Visa innehåll i närheten",
+    "search-events-max-distance": "Maximalt avstånd:",
+    "search-events-max-distance-aria-label": "Maximalt avstånd i kilometer",
     "pick-time-range": "Sök endast perioden",
     "event-search": "Sök",
     "event-name-or-place": "Innehållets namn och plats",

--- a/src/views/EventListing/__snapshots__/EventListing.test.js.snap
+++ b/src/views/EventListing/__snapshots__/EventListing.test.js.snap
@@ -920,6 +920,8 @@ exports[`EventListing Snapshot should render view correctly 1`] = `
       "search-event-button": "Hae sisältöjä",
       "search-events": "Etsi sisältöjä",
       "search-events-description": "Katsele kaikkia Linked Eventsin sisältöjä.",
+      "search-events-max-distance": "Etäisyys enintään:",
+      "search-events-max-distance-aria-label": "Etäisyys enintään kilometreissä",
       "search-events-near-me": "Näytä lähellä olevat sisällöt",
       "search-image-result": "Kuvapankissa {count} kuvaa {page} sivulla",
       "search-images": "Hae kuvan nimellä, ALT-tekstillä tai julkaisijan tai kuvaajan nimellä.",

--- a/src/views/Search/__snapshots__/Search.test.js.snap
+++ b/src/views/Search/__snapshots__/Search.test.js.snap
@@ -586,6 +586,8 @@ exports[`Search Snapshot should render view correctly 1`] = `
       "search-event-button": "Hae sisältöjä",
       "search-events": "Etsi sisältöjä",
       "search-events-description": "Katsele kaikkia Linked Eventsin sisältöjä.",
+      "search-events-max-distance": "Etäisyys enintään:",
+      "search-events-max-distance-aria-label": "Etäisyys enintään kilometreissä",
       "search-events-near-me": "Näytä lähellä olevat sisällöt",
       "search-image-result": "Kuvapankissa {count} kuvaa {page} sivulla",
       "search-images": "Hae kuvan nimellä, ALT-tekstillä tai julkaisijan tai kuvaajan nimellä.",

--- a/src/views/Search/index.scss
+++ b/src/views/Search/index.scss
@@ -13,6 +13,7 @@
 }
 
 .toggle-container{
+    margin-bottom: 1em;
     .location-error-message {
         margin-top: 0.5rem;
         width: fit-content;


### PR DESCRIPTION
# Event search: Allow selecting max distance to events
#### Co-authored-by: Awel Eshetu <awel.eshetu@anders.com>
#### Depends on https://github.com/City-of-Turku/linkedevents/pull/137

## Changes

Add a slider input for selecting the max distance to events when the 'Content near me' toggle is checked in the content search page and send the value as a query parameter when fetching events.

### [Trello card #407](https://trello.com/c/HI40Gioe/407-events-near-me-let-user-select-maximum-distance)

-----------------------------------------------------------------------------------------------
### Breakdown:

 1. src/constants.js 
     * Add a constant for the default max search distance
   
 2. src/views/EventListing/__snapshots__/EventListing.test.js.snap
     * Update snapshots
    
 3. src/views/Search/Search.test.js
     * Add test cases for the state and query parameters being set correctly
     
 4. src/views/Search/__snapshots__/Search.test.js.snap 
     * Update snapshots
   
 5. src/views/Search/index.js
     * Add slider for selecting the max search distance and handle query params
    
 6. src/views/Search/index.scss
      * Layout changes
